### PR TITLE
Fix mobile error display in quick-order list

### DIFF
--- a/docs/website/website-1/assets/quick-order-list.js
+++ b/docs/website/website-1/assets/quick-order-list.js
@@ -417,8 +417,13 @@ if (!customElements.get('quick-order-list')) {
           variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = message;
           variantItemErrorDesktop.closest('tr').classList.remove('hidden');
         }
-        if (variantItemErrorMobile)
+
+        const variantItemErrorMobile = document.getElementById(
+          `Quick-order-list-item-error-mobile-${id}`
+        );
+        if (variantItemErrorMobile) {
           variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = message;
+        }
 
         this.querySelector('#shopping-cart-variant-item-status').setAttribute('aria-hidden', true);
 


### PR DESCRIPTION
## Summary
- fix missing variable when updating quick-order errors on mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68763b894e508328a195e187e754fc63