### PR TITLE
Align footer logo and business info

### DIFF
--- a/clients/nome-ror-as/website/website7/assets/section-footer.css
+++ b/clients/nome-ror-as/website/website7/assets/section-footer.css
@@ -54,6 +54,14 @@
   width: 100%;
 }
 
+/* Group holding logo and business info */
+.footer__company-info-group {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+}
+
 @media screen and (max-width: 749px) {
   .footer__content-bottom {
     flex-wrap: wrap;
@@ -507,7 +515,7 @@
   }
 }
 .footer__business-info {
-  margin-left: auto;
+  margin-left: 0;
   padding-right: 2rem;
   max-width: 320px;
   text-align: right;
@@ -544,5 +552,8 @@
     text-align: left;
     font-size: 2rem;
     padding-top: 1.5rem;
+  }
+  .footer__company-info-group {
+    flex-direction: column;
   }
 }

--- a/clients/nome-ror-as/website/website7/sections/footer.liquid
+++ b/clients/nome-ror-as/website/website7/sections/footer.liquid
@@ -296,20 +296,22 @@
         {%- endif -%}
       </div>
     </div>
-   <div class="footer__content-bottom-wrapper page-width">
-      <div class="footer__block footer__logo-wrapper">
-        <img src="{{ 'Hvit.svg' | asset_url }}" alt="Nome Rør AS" class="footer-logo">
+    <div class="footer__content-bottom-wrapper page-width">
+      <div class="footer__company-info-group">
+        <div class="footer__block footer__logo-wrapper">
+          <img src="{{ 'Hvit.svg' | asset_url }}" alt="Nome Rør AS" class="footer-logo">
+        </div>
+        <div class="footer__block footer__business-info">
+          <ul>
+            <li><strong>Nome Rør AS</strong></li>
+            <li>Org nr: 935595916</li>
+            <li>Telefon: <a href="tel:+4790940810">909 40 810</a></li>
+            <li>Adresse: Nordskogvegen 46, 3825 Lunde</li>
+            <li>Åpningstider: 0800-1600</li>
+          </ul>
+        </div>
       </div>
-     <div class="footer__block footer__business-info">
-     <ul>
-       <li><strong>Nome Rør AS</strong></li>
-       <li>Org nr: 935595916</li>
-       <li>Telefon: <a href="tel:+4790940810">909 40 810</a></li>
-       <li>Adresse: Nordskogvegen 46, 3825 Lunde</li>
-       <li>Åpningstider: 0800-1600</li>
-     </ul>
-     </div>
-   </div>
+    </div>
     <div class="footer__content-bottom-wrapper page-width{% if section.settings.enable_country_selector == false and section.settings.enable_language_selector == false %} footer__content-bottom-wrapper--center{% endif %}">
       <div class="footer__copyright caption">
         <small class="copyright__content"


### PR DESCRIPTION
## Summary
- place logo and business info inside a flex wrapper
- make the group responsive with a mobile column layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b5079a808328991e57e89551dea6