### PR TITLE
Add developer setup guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,6 @@ This directory contains all project documentation.
 - [Agents Overview](AGENTS.md)
 - [Brand Guide](BRAND_GUIDE.md)
 - [Changelog](CHANGELOG.md)
-- [Project Setup](setup.md)
+- [Project Setup](SETUP.md)
 - [Folder Structure](folder-structure.txt)
 - [Internal Guidelines](internal-guidelines.md)

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,40 @@
+# Prosjektoppsett
+
+Denne guiden viser hvordan du klargjør utviklingsmiljøet lokalt.
+
+## 1. ✅ Forutsetninger
+- macOS, Linux eller WSL anbefales
+- Git
+- Node.js 20.10.0
+- pnpm 8.15.4
+- [mise](https://github.com/jdx/mise) som verktøyhåndtering
+
+## 2. 📦 Installer mise
+Kjør installasjonsskriptet:
+```bash
+curl https://mise.run | sh
+```
+
+Følg beskjedene for å legge mise i `PATH`.
+
+## 3. 💾 Hent repoet og aktiver versjoner
+```bash
+git clone <REPO-URL>
+cd nesheim-vatten
+mise use -g node@20.10.0
+mise use -g pnpm@8.15.4
+```
+
+Dette oppretter passende globale versjonslenker. Alternativt henter mise automatisk verdier fra `.tool-versions`.
+
+## 4. 📥 Installer avhengigheter
+```bash
+pnpm install
+```
+
+## 5. ✅ Valider oppsettet
+Kjør linters og tester for å bekrefte at alt fungerer:
+```bash
+pnpm run lint
+pnpm test
+```


### PR DESCRIPTION
## Summary
- add clear SETUP instructions for developers
- link to new setup guide in docs index

## Testing
- `npm run lint` *(fails: option exclude does not exist)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68838e94afbc8328818eff4798f03574