### PR TITLE
docs: add complete docs/SETUP.md and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Nesheim & Vatten delivers strategic consulting and creative services covering:
 
 ## Documentation
 Full project documentation is available in [docs/INDEX.md](docs/INDEX.md).
+For lokal oppsett se [docs/SETUP.md](docs/SETUP.md).
 
 ## Installation
 ```bash

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,40 +1,58 @@
 # Prosjektoppsett
 
-Denne guiden viser hvordan du klargjør utviklingsmiljøet lokalt.
+Denne guiden viser hvordan du klargjør utviklingsmiljøet lokalt slik at du kan begynne å bidra med en gang.
 
 ## 1. ✅ Forutsetninger
 - macOS, Linux eller WSL anbefales
-- Git
-- Node.js 20.10.0
-- pnpm 8.15.4
-- [mise](https://github.com/jdx/mise) som verktøyhåndtering
+- Git og SSH-nøkler konfigurert
+- Node.js 20
+- pnpm 8
+- [mise](https://github.com/jdx/mise) for verktøyhåndtering
 
 ## 2. 📦 Installer mise
 Kjør installasjonsskriptet:
 ```bash
 curl https://mise.run | sh
 ```
+Følg instruksjonene for å legge mise i `PATH`.
 
-Følg beskjedene for å legge mise i `PATH`.
+## 3. 🔁 Aktiver mise i shell
+Legg til mise-hooks i ditt skall (bash, zsh eller fish) ved å kjøre kommandoen som vises etter installasjonen. For å unngå advarsler anbefales det også å aktivere idiomatisk setting for Node:
+```bash
+mise settings add idiomatic_version_file_enable_tools node
+```
 
-## 3. 💾 Hent repoet og aktiver versjoner
+## 4. 💾 Hent repo og installer verktøy
 ```bash
 git clone <REPO-URL>
 cd nesheim-vatten
-mise use -g node@20.10.0
-mise use -g pnpm@8.15.4
+mise install
 ```
+`mise install` leser `.tool-versions` og installerer riktige versjoner av Node og andre verktøy.
 
-Dette oppretter passende globale versjonslenker. Alternativt henter mise automatisk verdier fra `.tool-versions`.
-
-## 4. 📥 Installer avhengigheter
+## 5. 📥 Installer avhengigheter
 ```bash
 pnpm install
 ```
+Evt. bruk `npm install` hvis du foretrekker npm.
 
-## 5. ✅ Valider oppsettet
-Kjør linters og tester for å bekrefte at alt fungerer:
+## 6. 🛠️ Kjør utviklingsserver
+```bash
+pnpm dev
+```
+Dette starter eventuelle lokale servere definert i `package.json`.
+
+## 7. 📝 Lint, test og build
+Kjør kvalitetskontroll og bygg lokalt når nødvendig:
 ```bash
 pnpm run lint
 pnpm test
+pnpm run build
 ```
+
+## 8. ❗ Vanlige feil og løsninger
+- **Feil Node-versjon:** Kjør `mise install` på nytt og start terminalen på nytt.
+- **pnpm ikke funnet:** Sjekk at mise har installert pnpm og at den er i `PATH`.
+- **Port opptatt ved `pnpm dev`:** Endre port i `.env` eller stopp prosessen som bruker porten.
+
+Følger du disse stegene skal du være klar til å utvikle uten ytterligere hjelp.


### PR DESCRIPTION
## Summary
- expand `docs/SETUP.md` with full local setup instructions
- mention the setup guide from `README.md`

## Testing
- `npm test`
- `npm run lint` *(fails: option exclude does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6883921fbc108328b7a5a2ad5a561b94