### PR TITLE
chore(github): add PR & Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,22 +1,20 @@
 ---
 name: Bug report
-about: Report a bug to help us improve
+about: Rapporter en feil som må fikses
 title: "[BUG]"
 labels: bug
 assignees: ''
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Beskrivelse**
+Kort beskrivelse av feilen.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**Steg for å gjenskape**
+1. ...
+2. ...
 
-**Expected behavior**
-What did you expect to happen?
+**Forventet oppførsel**
+Hva forventet du skulle skje?
 
-**Screenshots**
-If applicable, add screenshots.
-
-**Additional context**
-Add any other context about the problem here.
+**Tilleggsinformasjon**
+Eventuell ekstra kontekst eller skjermbilder.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Foreslå en ny funksjon eller forbedring
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+---
+
+**Hva og hvorfor**
+Forklar ønsket funksjon og hvorfor den er nyttig.
+
+**Løsningsforslag**
+Hvordan ser du for deg løsningen?
+
+**Tilleggsinformasjon**
+Eventuell ekstra kontekst.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Hva og hvorfor
+
+Beskriv kort hva som er endret og hvorfor endringen er nødvendig.
+
+## Endringer
+
+- Punkt 1
+- Punkt 2
+
+## Sjekkliste
+
+- [ ] Kjørte tester (`npm test`)
+- [ ] Kjørte linters (`npm run lint`)
+- [ ] Oppdatert dokumentasjon


### PR DESCRIPTION
## Summary
- add Norwegian PR template for explaining what and why
- create issue templates for bugs and features
- disable blank issues via config

## Testing
- `npm run lint` *(fails: option exclude does not exist)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883923ee2c883288f133e5c7f1721d9