### PR TITLE
docs: add documentation index to /docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,2 +1,9 @@
+# Documentation Index
 
+This folder collects internal documentation and guidelines for **Nesheim & Vatten Consulting**.
+Below are some key documents:
 
+- [ARCHITECTURE.md](ARCHITECTURE.md) – repository structure and folder overview
+- [BRAND_GUIDE.md](BRAND_GUIDE.md) – visual identity and asset usage
+- [SETUP.md](SETUP.md) – quick project setup instructions
+- [internal-guidelines.md](internal-guidelines.md) – internal processes and best practices


### PR DESCRIPTION
## Hva og hvorfor
- docs/README.md was empty, providing no guidance
- added quick index to highlight key documentation

## Endringer
- wrote a short intro for the docs folder
- linked to ARCHITECTURE.md, BRAND_GUIDE.md, SETUP.md and internal-guidelines.md

## Sjekkliste
- [ ] Kjørte tester (`npm test`)
- [ ] Kjørte linters (`npm run lint`)
- [x] Oppdatert dokumentasjon

`npm install`, `npm run lint` and `npm test` all failed because `package.json` is malformed.

------
https://chatgpt.com/codex/tasks/task_e_68839896cc748328b25afcc24daae561