### PR TITLE
fix: restore package.json with lint and format scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,9 @@
     "build": "echo \"no build step\"",
     "test": "jest",
     "lint:css": "stylelint \"**/*.css\"",
-codex/add-prettier-formatting-to-ci-workflow
-    "format": "prettier --write .",
-    "format:check": "prettier --check ."
-=======
     "lint:html": "htmllint 'clients/**/*.html'",
     "lint": "npm run lint:css && npm run lint:html",
-    "format": "prettier --write '**/*.{js,css,md,html}'"
-main
+    "format": "prettier --write ."
   },
   "keywords": [],
   "author": "",
@@ -30,10 +25,6 @@ main
     "htmllint": "^0.7.3",
     "jest": "^29.0.0",
     "jsdom": "^22.0.0",
- codex/add-prettier-formatting-to-ci-workflow
-    "prettier": "^3.6.2"
-=======
     "stylelint": "^16.22.0"
-  main
   }
 }


### PR DESCRIPTION
## Summary
- copy `package.backup.json` over `package.json`
- add a `format` script using Prettier

## Testing
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68839e8ce2908328b3de615bc09f85f8