### PR TITLE
Fix CI to tolerate package-lock conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: npm install
+      - run: npm install --package-lock=false
+        # AGENTS.md allows merge markers in package-lock.json
       - run: npm run lint
       - run: npm run format:check
 
@@ -25,5 +26,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: npm install
+      - run: npm install --package-lock=false
+        # AGENTS.md allows merge markers in package-lock.json
       - run: npm test --silent


### PR DESCRIPTION
## Hva og hvorfor
- workflowen stoppet når package-lock.json inneholdt konfliktmarkører
- AGENTS.md sier at dette er lov, så CI må ignorere filen

## Endringer
- npm install kjøres nå med `--package-lock=false`
- lagt inn kommentar som peker til AGENTS.md

## Sjekkliste
- [x] Kjørte tester (`npm test`)
- [x] Kjørte linters (`npm run lint`)
- [ ] Oppdatert dokumentasjon

------
https://chatgpt.com/codex/tasks/task_e_6883e1e1559483288cc67dcd31bf24bc