### PR TITLE
Fix DECO 5000 release metadata

### DIFF
--- a/clients/comma/artists/deco-5000/docs/discography.md
+++ b/clients/comma/artists/deco-5000/docs/discography.md
@@ -2,13 +2,16 @@
 
 | Title | Release Date | Label | Format | Role | Links | Description |
 |------|-------------|-------|--------|------|-------|-------------|
-| She Left in the Morning | 2020-03-15 | COMMA. | Single | Original | [Link](#) | Early track showcasing dreamy pads and a hint of the fast trance style to come. |
-| Beyond Time | 2021-05-01 | COMMA. | Single | Original | [Link](#) | Uptempo trance anthem that gained support on Oslo underground radio. |
+| She Left in the Morning | 2020-10-17 | Self-released | Single | Original | [Link](#) | Early track showcasing dreamy pads and a hint of the fast trance style to come. |
+| Berlin 03 | 2020-11-06 | Self-released | Single | Original | [Link](#) | Follow-up single capturing early neotrance ideas with raw energy. |
+| Nightswimmer | 2021-02-13 | Normative | Compilation Track | Original | [Link](#) | Featured on Normative's debut sampler highlighting emerging artists. |
+| Beyond Time | 2021-06-16 | Self-released | Single | Original | [Link](#) | Uptempo trance anthem that gained support on Oslo underground radio. |
 | Exporter Groove Estate | 2021-11-20 | COMMA. | Compilation Contribution | Collab | [Link](#) | Featured on a local electronic compilation, experimenting with progressive elements. |
-| Drifting with Tommy EP | 2022-04-10 | COMMA. | EP | Collaboration | [Link](#) | Joint EP with friend Tommy exploring melodic side‑chains and ethereal breakdowns. |
-| Cosmic Sense EP | 2022-09-22 | COMMA. | EP | Original | [Link](#) | Four-track release mixing classic trance basslines with modern synth work. |
-| Her Faded Mind | 2022-12-01 | COMMA. | Single | Original | [Link](#) | Somber yet driving single that became a favourite in Oslo club sets. |
-| Dyonis | 2023-05-18 | COMMA. | Single | Original | [Link](#) | Peak-time anthem with crisp percussion and euphoric lead lines. |
+| Drifting with Tommy EP | 2022-02-18 | Mhost Likely Black | EP | Collaboration | [Link](#) | Joint EP with friend Tommy exploring melodic side‑chains and ethereal breakdowns. |
+| Cosmic Sense EP | 2022-07-01 | Groove Estate Records | EP | Original | [Link](#) | Four-track release mixing classic trance basslines with modern synth work. |
+| Her Faded Mind | 2022-07-16 | Underzone | Single | Original | [Link](#) | Somber yet driving single that became a favourite in Oslo club sets. |
+| Dyonis | 2023-06-29 | Atom Trance Force | Single | Original | [Link](#) | Peak-time anthem with crisp percussion and euphoric lead lines. |
+| Echoes (feat. Europe) | 2023-12-22 | Underzone | Compilation Track | Collaboration | [Link](#) | Collaborative piece released on Underzone's year-end compilation. |
 | Luca | 2024-02-07 | COMMA. | Single | Original | [Link](#) | Warm-up track with nostalgic melodies and airy vocals. |
 | Reasons | 2024-04-19 | COMMA. | Single | Original | [Link](#) | High-energy tune emphasising the "5K" live style. |
 | Blue Skies w/ TDJ | 2024-09-10 | COMMA. | Single | Collaboration | [Link](#) | Vocal collaboration with TDJ blending Montreal and Oslo trance flavours. |

--- a/clients/comma/artists/deco-5000/docs/legal/licensing-deco-5000.md
+++ b/clients/comma/artists/deco-5000/docs/legal/licensing-deco-5000.md
@@ -1,10 +1,10 @@
 # Licensing & Rights Information – DECO 5000
 
 ## Track Ownership
-All compositions and masters released under the name DECO 5000 are owned by Herman Marensius Gjersøe and licensed exclusively to the COMMA. label.
+All compositions and masters are owned by Herman Marensius Gjersøe. Early singles were self-released or issued through partner labels. Starting with *Decosystema Vol. 1*, recordings are licensed exclusively to the COMMA. label.
 
 ## Label/Artist Rights
-COMMA. holds distribution and promotional rights for all DECO 5000 material. Herman Marensius Gjersøe retains authorship and performance rights under the DECO 5000 alias. This project is separate from his work as Marensius and does not include any activities with Hovland.
+COMMA. handles distribution and promotion for releases from 2025 onward. Herman Marensius Gjersøe retains authorship and performance rights under the DECO 5000 alias. This project is separate from his work as Marensius and does not include any activities with Hovland.
 
 ## Usage for Press & DJs
 Approved press outlets and DJs may stream and broadcast DECO 5000 tracks for promotional purposes with proper credit. Any remix, edit or sync licensing request must be cleared through COMMA.

--- a/clients/comma/artists/deco-5000/docs/legal/rights-and-ownership.md
+++ b/clients/comma/artists/deco-5000/docs/legal/rights-and-ownership.md
@@ -1,6 +1,6 @@
 # Rights and Ownership
 
-All masters and compositions are owned by Herman Marensius Gjersøe under the DECO 5000 alias and licensed exclusively to COMMA. Artwork remains property of the respective designers.
+All masters and compositions are owned by Herman Marensius Gjersøe under the DECO 5000 alias. Early material was self-released or issued on partner labels, while *Decosystema Vol. 1* and later works are licensed exclusively to COMMA. Artwork remains property of the respective designers.
 
 ## Copyright Statement
 ```

--- a/clients/comma/artists/deco-5000/releases/2020/berlin-03.md
+++ b/clients/comma/artists/deco-5000/releases/2020/berlin-03.md
@@ -1,0 +1,8 @@
+# Berlin 03
+
+- **Release Date:** 2020-11-06
+- **Label:** Self-released
+- **Format:** Single
+- **Platforms:** Bandcamp
+
+Follow-up single capturing early neotrance ideas with raw energy.

--- a/clients/comma/artists/deco-5000/releases/2020/she-left-in-the-morning.md
+++ b/clients/comma/artists/deco-5000/releases/2020/she-left-in-the-morning.md
@@ -1,7 +1,7 @@
 # She Left in the Morning
 
-- **Release Date:** 2020-03-15
-- **Label:** COMMA.
+- **Release Date:** 2020-10-17
+- **Label:** Self-released
 - **Format:** Single
 - **Platforms:** Spotify, Apple Music
 

--- a/clients/comma/artists/deco-5000/releases/2021/beyond-time.md
+++ b/clients/comma/artists/deco-5000/releases/2021/beyond-time.md
@@ -1,7 +1,7 @@
 # Beyond Time
 
-- **Release Date:** 2021-05-01
-- **Label:** COMMA.
+- **Release Date:** 2021-06-16
+- **Label:** Self-released
 - **Format:** Single
 - **Platforms:** Spotify, Apple Music
 

--- a/clients/comma/artists/deco-5000/releases/2021/nightswimmer.md
+++ b/clients/comma/artists/deco-5000/releases/2021/nightswimmer.md
@@ -1,0 +1,8 @@
+# Nightswimmer
+
+- **Release Date:** 2021-02-13
+- **Label:** Normative
+- **Format:** Compilation track (VA: *Normative Young Guns I*, NMYG001)
+- **Platforms:** Bandcamp
+
+Featured on Normative's debut sampler highlighting emerging artists.

--- a/clients/comma/artists/deco-5000/releases/2022/cosmic-sense-ep.md
+++ b/clients/comma/artists/deco-5000/releases/2022/cosmic-sense-ep.md
@@ -1,7 +1,7 @@
 # Cosmic Sense EP
 
-- **Release Date:** 2022-09-22
-- **Label:** COMMA.
+- **Release Date:** 2022-07-01
+- **Label:** Groove Estate Records
 - **Format:** EP
 - **Platforms:** Spotify, Bandcamp
 

--- a/clients/comma/artists/deco-5000/releases/2022/drifting-with-tommy-ep.md
+++ b/clients/comma/artists/deco-5000/releases/2022/drifting-with-tommy-ep.md
@@ -1,7 +1,7 @@
 # Drifting with Tommy EP
 
-- **Release Date:** 2022-04-10
-- **Label:** COMMA.
+- **Release Date:** 2022-02-18
+- **Label:** Mhost Likely Black
 - **Format:** EP
 - **Platforms:** Spotify, Apple Music, Bandcamp
 

--- a/clients/comma/artists/deco-5000/releases/2022/her-faded-mind.md
+++ b/clients/comma/artists/deco-5000/releases/2022/her-faded-mind.md
@@ -1,7 +1,7 @@
 # Her Faded Mind
 
-- **Release Date:** 2022-12-01
-- **Label:** COMMA.
+- **Release Date:** 2022-07-16
+- **Label:** Underzone
 - **Format:** Single
 - **Platforms:** Spotify, Apple Music
 

--- a/clients/comma/artists/deco-5000/releases/2023/dyonis.md
+++ b/clients/comma/artists/deco-5000/releases/2023/dyonis.md
@@ -1,7 +1,7 @@
 # Dyonis
 
-- **Release Date:** 2023-05-18
-- **Label:** COMMA.
+- **Release Date:** 2023-06-29
+- **Label:** Atom Trance Force
 - **Format:** Single
 - **Platforms:** Spotify, Apple Music
 

--- a/clients/comma/artists/deco-5000/releases/2023/echoes-feat-europe.md
+++ b/clients/comma/artists/deco-5000/releases/2023/echoes-feat-europe.md
@@ -1,0 +1,8 @@
+# Echoes (feat. Europe)
+
+- **Release Date:** 2023-12-22
+- **Label:** Underzone (VA: *Varios Artistas VIII*)
+- **Format:** Compilation track
+- **Platforms:** Bandcamp
+
+Collaborative piece released on Underzone's year-end compilation.


### PR DESCRIPTION
## Summary
- correct release metadata for DECO 5000 and add missing entries
- clarify licensing docs about early self-releases

## Testing
- `npm install`
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886bd5334b083288e8cb8326f96f3f9