### PR TITLE
Add Hovland brand guide

### DIFF
--- a/clients/comma/artists/hovland/branding/BRAND_GUIDE.md
+++ b/clients/comma/artists/hovland/branding/BRAND_GUIDE.md
@@ -1,0 +1,46 @@
+# Brand Guide – Hovland
+
+## Brand Overview
+Hovland explores ambient and progressive house under the COMMA. label. All visuals and messaging reflect the label's clean, minimal style.
+
+## Visual Style
+- White backgrounds (`#ffffff`) with black text (`#000000`)
+- `Arial, sans-serif` fonts
+- 2 rem body padding, no extra decoration
+- Tone is calm and concise
+
+## Color Palette
+| Color | Hex | Usage |
+|-------|-----|-------|
+| Background | `#ffffff` | default page background |
+| Text | `#000000` | headings and body text |
+| Accent | _TBD_ | optional artist highlight |
+
+## Logo Usage
+- Store logo files in `branding/logo/`
+- Keep at least 24 px clear space
+- Use high-contrast placement (black on white or inverted)
+- Left or center align
+
+## Typography
+| Style | Font | Notes |
+|-------|------|-------|
+| Display | `Arial, sans-serif` | page titles |
+| Body | `Arial, sans-serif` | general copy |
+
+## Social Style Guide
+- Minimal captions, short sentences
+- At most one emoji per post
+- Reference handles in lowercase (e.g. `@hovlandmusic_`)
+- Maintain a neutral, understated voice
+
+## Content Guidelines
+- Photos: neutral color grading, subtle contrast
+- Prefer simple grid layouts with minimal overlays
+- Keep tone consistent across all platforms
+
+## File Directory Overview
+- `branding/` – logos and this guide
+- `assets/` – artwork, images and audio clips
+- `social/` – ready-made posts
+- `epk/` – press kit materials


### PR DESCRIPTION
## Summary
- create BRAND_GUIDE for Hovland in artists/hovland/branding
- outline colors, typography, social tone and file layout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68891bc5609c8328a4ae7be821f592e5