### PR TITLE
Fix duplicate h1 in product modal

### DIFF
--- a/docs/website/sections/main-product.liquid
+++ b/docs/website/sections/main-product.liquid
@@ -688,7 +688,7 @@
             {{- 'icon-close.svg' | inline_asset_content -}}
           </button>
           <div class="product-popup-modal__content-info">
-            <h1 class="h2">{{ block.settings.page.title | escape }}</h1>
+            <h2 class="h2">{{ block.settings.page.title | escape }}</h2>
             {{ block.settings.page.content }}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- demote duplicate heading from `<h1>` to `<h2>` in `main-product.liquid`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889343c0e90832895ec089a064da721