### PR TITLE
Add JSON‑LD markup for product and article

### DIFF
--- a/docs/website/sections/main-article.liquid
+++ b/docs/website/sections/main-article.liquid
@@ -289,7 +289,23 @@
 </article>
 
 <script type="application/ld+json">
-  {{ article | structured_data }}
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": {{ article.title | json }},
+    {% if article.image %}
+    "image": [{{ article.image | image_url | json }}],
+    {% endif %}
+    "datePublished": {{ article.published_at | date: '%Y-%m-%d' | json }},
+    "author": {
+      "@type": "Person",
+      "name": {{ article.author | json }}
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": {{ article.url | json }}
+    }
+  }
 </script>
 
 {% schema %}

--- a/docs/website/sections/main-product.liquid
+++ b/docs/website/sections/main-product.liquid
@@ -716,7 +716,23 @@
     -%}
 
     <script type="application/ld+json">
-      {{ product | structured_data }}
+      {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": {{ product.title | json }},
+        {% if seo_media %}
+        "image": [{{ seo_media | image_url | json }}],
+        {% endif %}
+        "description": {{ product.description | strip_html | json }},
+        "sku": {{ product.selected_or_first_available_variant.sku | json }},
+        "offers": {
+          "@type": "Offer",
+          "priceCurrency": {{ shop.currency | json }},
+          "price": {{ product.selected_or_first_available_variant.price | money_without_currency | json }},
+          "availability": "https://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}",
+          "url": {{ shop.url | append: product.url | json }}
+        }
+      }
     </script>
   </div>
 </product-info>


### PR DESCRIPTION
## Summary
- define product rich results in `main-product.liquid`
- define article rich results in `main-article.liquid`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68893443089c8328b44c33b4f3174992