### PR TITLE
Add alt text guidance for snippet images

### DIFF
--- a/clients/comma/website/comma-website_v2/seo/README.md
+++ b/clients/comma/website/comma-website_v2/seo/README.md
@@ -15,6 +15,7 @@ Add structured data as needed. Placeholder for future schema snippets.
 
 - [ ] All images include meaningful `alt` attributes
 - [ ] Decorative images use empty alt tags (`alt=""`)
+- [ ] Theme snippets add `role="presentation"` with `alt=""` for decorative images
 
 ## Sitemap Audit
 

--- a/clients/comma/website/comma-website_v2/snippets/icon-with-text.liquid
+++ b/clients/comma/website/comma-website_v2/snippets/icon-with-text.liquid
@@ -51,6 +51,7 @@
             alt="{{ block.settings.image_1.alt | escape }}"
           {% else %}
             role="presentation"
+            alt=""
           {% endif %}
           height="auto"
           width="auto"
@@ -73,6 +74,7 @@
             alt="{{ block.settings.image_2.alt | escape }}"
           {% else %}
             role="presentation"
+            alt=""
           {% endif %}
           height="auto"
           width="auto"
@@ -95,6 +97,7 @@
             alt="{{ block.settings.image_3.alt | escape }}"
           {% else %}
             role="presentation"
+            alt=""
           {% endif %}
           height="auto"
           width="auto"


### PR DESCRIPTION
## Summary
- ensure decorative images use empty alt attributes in `icon-with-text` snippet
- mention `role="presentation"` rule in SEO checklist

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889345d959883289f0a08478d0112c4