### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,18 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Run Lighthouse CI
+        run: npx lhci autorun --config=lighthouserc.json

--- a/clients/comma/website/comma-website_v2/performance/README.md
+++ b/clients/comma/website/comma-website_v2/performance/README.md
@@ -20,3 +20,11 @@ Guidelines for keeping the COMMA site fast and efficient.
 ## Unused Assets
 
 Periodically review loaded scripts and stylesheets to remove anything not in use.
+
+## Automated Lighthouse Checks
+
+The repository includes a GitHub Actions workflow that runs
+[Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) on each push and
+pull request. The workflow serves the staged theme build and fails if any
+category score falls below **90**. Review the `Lighthouse CI` job under the
+Actions tab for detailed results.

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,15 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "clients/comma/website/comma-website_v2"
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", {"minScore": 0.9}],
+        "categories:accessibility": ["error", {"minScore": 0.9}],
+        "categories:best-practices": ["error", {"minScore": 0.9}],
+        "categories:seo": ["error", {"minScore": 0.9}]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- automate performance checks using Lighthouse CI
- assert minimum scores via `lighthouserc.json`
- document the new workflow

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_688934681e988328b1cee1eb4be8ceb2