### PR TITLE
Update lint and format globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "test": "jest",
     "lint": "npm run lint:css && npm run lint:html",
     "lint:css": "stylelint \"**/*.css\"",
-    "lint:html": "htmllint \"clients/baattilsyn/pages/*.html\"",
+    "lint:html": "htmllint \"clients/**/*.html\"",
     "dev": "npx serve clients/baattilsyn/pages",
-    "format": "prettier -w clients/baattilsyn/website/website-tests/website_test1",
-    "format:check": "prettier -c clients/baattilsyn/website/website-tests/website_test1"
+    "format": "prettier -w \"**/*.{js,css,html}\"",
+    "format:check": "prettier -c \"**/*.{js,css,html}\""
   },
   "devDependencies": {
     "htmllint": "^0.7.3",


### PR DESCRIPTION
## Summary
- update htmllint glob to lint all client HTML
- widen prettier globs for format scripts
- keep Liquid and template JSON ignored

## Testing
- `npm run format:check` *(fails: Error occurred when checking code style)*
- `npm run lint` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68893bd6f2d08328b8935074e77f8a62