### PR TITLE
Add global subscribe mock in QuickAddBulk test

### DIFF
--- a/clients/baattilsyn/website/website-tests/website_test2/assets/section-footer.css
+++ b/clients/baattilsyn/website/website-tests/website_test2/assets/section-footer.css
@@ -196,7 +196,8 @@
     margin: 0;
   }
 
-  .footer-block__newsletter:not(:only-child) .newsletter-form__message--success {
+  .footer-block__newsletter:not(:only-child)
+    .newsletter-form__message--success {
     left: auto;
   }
 
@@ -296,7 +297,8 @@
 }
 
 @media screen and (min-width: 750px) {
-  .footer__content-bottom-wrapper:not(.footer__content-bottom-wrapper--center) .footer__copyright {
+  .footer__content-bottom-wrapper:not(.footer__content-bottom-wrapper--center)
+    .footer__copyright {
     text-align: right;
   }
 }
@@ -420,7 +422,9 @@
   text-align: center;
 }
 
-.footer-block:only-child > .footer-block__brand-info > .footer-block__image-wrapper {
+.footer-block:only-child
+  > .footer-block__brand-info
+  > .footer-block__image-wrapper {
   margin-left: auto;
   margin-right: auto;
 }
@@ -430,7 +434,9 @@
   height: auto;
 }
 
-.footer-block:only-child .footer-block__brand-info .footer__list-social.list-social {
+.footer-block:only-child
+  .footer-block__brand-info
+  .footer__list-social.list-social {
   justify-content: center;
 }
 
@@ -505,8 +511,8 @@
       padding-left: 3rem;
     }
   }
-}.
-.footer__company-info-group {
+}
+. .footer__company-info-group {
   display: flex;
   justify-content: right;
   align-items: center;
@@ -528,7 +534,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: clamp(1rem, 3vw, 3rem)
+  gap: clamp(1rem, 3vw, 3rem);
   max-width: 1100px;
   margin: 0 auto;
   flex-wrap: wrap;

--- a/clients/baattilsyn/website/website-tests/website_test3/assets/section-footer.css
+++ b/clients/baattilsyn/website/website-tests/website_test3/assets/section-footer.css
@@ -196,7 +196,8 @@
     margin: 0;
   }
 
-  .footer-block__newsletter:not(:only-child) .newsletter-form__message--success {
+  .footer-block__newsletter:not(:only-child)
+    .newsletter-form__message--success {
     left: auto;
   }
 
@@ -296,7 +297,8 @@
 }
 
 @media screen and (min-width: 750px) {
-  .footer__content-bottom-wrapper:not(.footer__content-bottom-wrapper--center) .footer__copyright {
+  .footer__content-bottom-wrapper:not(.footer__content-bottom-wrapper--center)
+    .footer__copyright {
     text-align: right;
   }
 }
@@ -420,7 +422,9 @@
   text-align: center;
 }
 
-.footer-block:only-child > .footer-block__brand-info > .footer-block__image-wrapper {
+.footer-block:only-child
+  > .footer-block__brand-info
+  > .footer-block__image-wrapper {
   margin-left: auto;
   margin-right: auto;
 }
@@ -430,7 +434,9 @@
   height: auto;
 }
 
-.footer-block:only-child .footer-block__brand-info .footer__list-social.list-social {
+.footer-block:only-child
+  .footer-block__brand-info
+  .footer__list-social.list-social {
   justify-content: center;
 }
 
@@ -505,8 +511,8 @@
       padding-left: 3rem;
     }
   }
-}.
-.footer__company-info-group {
+}
+. .footer__company-info-group {
   display: flex;
   justify-content: right;
   align-items: center;
@@ -528,7 +534,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: clamp(1rem, 3vw, 3rem)
+  gap: clamp(1rem, 3vw, 3rem);
   max-width: 1100px;
   margin: 0 auto;
   flex-wrap: wrap;

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+global.subscribe = jest.fn();
+
 describe('QuickAddBulk.renderSections', () => {
   let window, document, QuickAddBulk, instance;
 


### PR DESCRIPTION
## Summary
- mock global.subscribe in quick-add-bulk tests
- fix CSS syntax errors preventing formatting

## Testing
- `npx prettier -w tests/quick-add-bulk.test.js clients/baattilsyn/website/website-tests/website_test2/assets/section-footer.css clients/baattilsyn/website/website-tests/website_test3/assets/section-footer.css`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688947a4a9988328aceac360bd73fcbe