### PR TITLE
Fix subscribe mock order for QuickAddBulk tests

### DIFF
--- a/docs/website/website-v1/assets/quick-add-bulk.js
+++ b/docs/website/website-v1/assets/quick-add-bulk.js
@@ -21,20 +21,22 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       connectedCallback() {
-        this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
-          if (
-            event.source === 'quick-add' ||
-            (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||
-            (event.cartData.variant_id && !(event.cartData.variant_id === parseInt(this.dataset.index)))
-          ) {
-            return;
-          }
-          // If its another section that made the update
-          this.onCartUpdate().then(() => {
-            this.listenForActiveInput();
-            this.listenForKeydown();
+        if (typeof subscribe === 'function') {
+          this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
+            if (
+              event.source === 'quick-add' ||
+              (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||
+              (event.cartData.variant_id && !(event.cartData.variant_id === parseInt(this.dataset.index)))
+            ) {
+              return;
+            }
+            // If its another section that made the update
+            this.onCartUpdate().then(() => {
+              this.listenForActiveInput();
+              this.listenForKeydown();
+            });
           });
-        });
+        }
       }
 
       disconnectedCallback() {

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -2,12 +2,12 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
-global.subscribe = jest.fn();
-
 describe('QuickAddBulk.renderSections', () => {
   let window, document, QuickAddBulk, instance;
 
   beforeEach(() => {
+    global.subscribe = jest.fn();
+
     const dom = new JSDOM(
       `<!DOCTYPE html><cart-drawer><div id="CartDrawer" class="drawer__inner"></div></cart-drawer><div id="cart-icon-bubble"></div>`,
       { url: 'https://example.com' }
@@ -19,6 +19,7 @@ describe('QuickAddBulk.renderSections', () => {
     global.DOMParser = window.DOMParser;
     global.HTMLElement = window.HTMLElement;
     global.customElements = window.customElements;
+    window.subscribe = global.subscribe;
     global.debounce = (fn) => fn;
     global.ON_CHANGE_DEBOUNCE_TIMER = 0;
     global.BulkAdd = class extends window.HTMLElement {
@@ -54,6 +55,7 @@ describe('QuickAddBulk.renderSections', () => {
     delete global.DOMParser;
     delete global.HTMLElement;
     delete global.customElements;
+    delete global.subscribe;
   });
 
   test('toggles is-empty when cart is empty', () => {


### PR DESCRIPTION
## Summary
- ensure `subscribe` is mocked after `JSDOM` setup so the custom element can use it
- clean up after tests
- guard `subscribe` usage in the component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68894a8fc3ac8328bacf8ecca00f7bc4