### PR TITLE
Fix ReferenceError for global subscribe in tests

### DIFF
--- a/docs/website/website-v1/assets/quick-add-bulk.js
+++ b/docs/website/website-v1/assets/quick-add-bulk.js
@@ -1,3 +1,5 @@
+globalThis.subscribe = globalThis.subscribe || undefined;
+
 if (!customElements.get('quick-add-bulk')) {
   customElements.define(
     'quick-add-bulk',
@@ -21,7 +23,7 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       connectedCallback() {
-        if (typeof subscribe === 'function') {
+        if (typeof globalThis.subscribe === 'function') {
           this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
             if (
               event.source === 'quick-add' ||

--- a/docs/website/website-v1/assets/quick-order-list.js
+++ b/docs/website/website-v1/assets/quick-order-list.js
@@ -1,3 +1,5 @@
+globalThis.subscribe = globalThis.subscribe || undefined;
+
 if (!customElements.get('quick-order-list')) {
   customElements.define(
     'quick-order-list',

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -41,8 +41,8 @@ describe('QuickAddBulk.renderSections', () => {
       __dirname,
       '../docs/website/website-v1/assets/quick-add-bulk.js'
     );
-    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-    window.Function(scriptContent).call(window);
+    delete require.cache[require.resolve(scriptPath)];
+    require(scriptPath);
     QuickAddBulk = window.customElements.get('quick-add-bulk');
     instance = new QuickAddBulk();
     document.body.appendChild(instance);


### PR DESCRIPTION
## Summary
- initialize `subscribe` on `globalThis` in cart components
- guard against missing `subscribe` in `QuickAddBulk`
- load component scripts via `require` after mocking globals in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894cce89d083289344092457d3ec0a