### PR TITLE
Fix QuickAddBulk subscribe check

### DIFF
--- a/docs/website/website-v1/assets/quick-add-bulk.js
+++ b/docs/website/website-v1/assets/quick-add-bulk.js
@@ -1,3 +1,4 @@
+var subscribe;
 globalThis.subscribe = globalThis.subscribe || undefined;
 
 if (!customElements.get('quick-add-bulk')) {
@@ -24,7 +25,9 @@ if (!customElements.get('quick-add-bulk')) {
 
       connectedCallback() {
         if (typeof globalThis.subscribe === 'function') {
-          this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
+          this.cartUpdateUnsubscriber = globalThis.subscribe(
+            PUB_SUB_EVENTS.cartUpdate,
+            (event) => {
             if (
               event.source === 'quick-add' ||
               (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -7,6 +7,7 @@ describe('QuickAddBulk.renderSections', () => {
 
   beforeEach(() => {
     global.subscribe = jest.fn();
+    global.PUB_SUB_EVENTS = { cartUpdate: 'cart-update' };
 
     const dom = new JSDOM(
       `<!DOCTYPE html><cart-drawer><div id="CartDrawer" class="drawer__inner"></div></cart-drawer><div id="cart-icon-bubble"></div>`,
@@ -56,6 +57,7 @@ describe('QuickAddBulk.renderSections', () => {
     delete global.HTMLElement;
     delete global.customElements;
     delete global.subscribe;
+    delete global.PUB_SUB_EVENTS;
   });
 
   test('toggles is-empty when cart is empty', () => {


### PR DESCRIPTION
## Summary
- guard against missing `subscribe` in `quick-add-bulk.js`
- mock `subscribe` and `PUB_SUB_EVENTS` before importing in the test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894edb52008328a72766270fca8a99