### PR TITLE
Add semantic wrappers for header and footer

### DIFF
--- a/clients/baattilsyn/website/website_v4/layout/theme.liquid
+++ b/clients/baattilsyn/website/website_v4/layout/theme.liquid
@@ -310,13 +310,17 @@
       {%- render 'cart-drawer' -%}
     {%- endif -%}
 
-    {% sections 'header-group' %}
+    <header>
+      {% sections 'header-group' %}
+    </header>
 
     <main id="MainContent" class="content-for-layout focus-none" role="main" tabindex="-1">
       {{ content_for_layout }}
     </main>
 
-    {% sections 'footer-group' %}
+    <footer>
+      {% sections 'footer-group' %}
+    </footer>
 
     <ul hidden>
       <li id="a11y-refresh-page-message">{{ 'accessibility.refresh_page' | t }}</li>


### PR DESCRIPTION
## Summary
- wrap Shopify layout groups with `<header>` and `<footer>` tags

## Testing
- `npm run lint:html` *(fails: found 21 errors out of 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_68895876d8c48328be0c07f4d5347a26