### PR TITLE
Add lazy loading to Båttilsyn pages

### DIFF
--- a/clients/baattilsyn/pages/index.html
+++ b/clients/baattilsyn/pages/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
         <header>
-          <img src="../assets/logo.svg" alt="Båttilsyn logo" />
+          <img src="../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
           <a href="index.html">Hjem</a>
@@ -25,10 +25,10 @@
           </section>
         </main>
         <footer>
-          <div class="sponsors">
-            <h3>Sponsorer</h3>
+          <details class="sponsors">
+            <summary>Sponsorer</summary>
             <p>Plass til sponsorer.</p>
-          </div>
+          </details>
         </footer>
 </body>
 </html>

--- a/clients/baattilsyn/pages/kontakt-oss.html
+++ b/clients/baattilsyn/pages/kontakt-oss.html
@@ -9,7 +9,7 @@
 </head>
 <body>
         <header>
-          <img src="../assets/logo.svg" alt="Båttilsyn logo" />
+          <img src="../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
           <a href="index.html">Hjem</a>
@@ -21,10 +21,10 @@
           <p>E-post: <a href="mailto:post@baattilsyn.no">post@baattilsyn.no</a></p>
         </main>
         <footer>
-          <div class="sponsors">
-            <h3>Sponsorer</h3>
+          <details class="sponsors">
+            <summary>Sponsorer</summary>
             <p>Plass til sponsorer.</p>
-          </div>
+          </details>
         </footer>
 </body>
 </html>

--- a/clients/baattilsyn/pages/tjenester.html
+++ b/clients/baattilsyn/pages/tjenester.html
@@ -9,7 +9,7 @@
 </head>
 <body>
         <header>
-          <img src="../assets/logo.svg" alt="Båttilsyn logo" />
+          <img src="../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
           <a href="index.html">Hjem</a>
@@ -21,10 +21,10 @@
           <p>Vi tilbyr tilsyn, vedlikehold og rapportering av din båt.</p>
         </main>
         <footer>
-          <div class="sponsors">
-            <h3>Sponsorer</h3>
+          <details class="sponsors">
+            <summary>Sponsorer</summary>
             <p>Plass til sponsorer.</p>
-          </div>
+          </details>
         </footer>
 </body>
 </html>

--- a/clients/baattilsyn/website/baattilsyn-website-v1/index.html
+++ b/clients/baattilsyn/website/baattilsyn-website-v1/index.html
@@ -12,8 +12,8 @@
     </head>
     <body>
         <header>
-            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" />
-            <img src="../../assets/logo.svg" alt="Båttilsyn logo" />
+            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
+            <img src="../../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
             <a href="index.html">Hjem</a>
@@ -54,10 +54,10 @@
             </section>
         </main>
         <footer>
-            <div class="sponsors">
-                <h3>Sponsorer</h3>
+            <details class="sponsors">
+                <summary>Sponsorer</summary>
                 <p>Plass til sponsorer.</p>
-            </div>
+            </details>
         </footer>
     </body>
 </html>

--- a/clients/baattilsyn/website/baattilsyn-website-v1/kontakt-oss.html
+++ b/clients/baattilsyn/website/baattilsyn-website-v1/kontakt-oss.html
@@ -12,8 +12,8 @@
     </head>
     <body>
         <header>
-            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" />
-            <img src="../../assets/logo.svg" alt="Båttilsyn logo" />
+            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
+            <img src="../../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
             <a href="index.html">Hjem</a>
@@ -38,10 +38,10 @@
             </form>
         </main>
         <footer>
-            <div class="sponsors">
-                <h3>Sponsorer</h3>
+            <details class="sponsors">
+                <summary>Sponsorer</summary>
                 <p>Plass til sponsorer.</p>
-            </div>
+            </details>
         </footer>
     </body>
 </html>

--- a/clients/baattilsyn/website/baattilsyn-website-v1/kontakt.html
+++ b/clients/baattilsyn/website/baattilsyn-website-v1/kontakt.html
@@ -12,8 +12,8 @@
     </head>
     <body>
         <header>
-            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" />
-            <img src="../../assets/logo.svg" alt="Båttilsyn logo" />
+            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
+            <img src="../../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
             <a href="index.html">Hjem</a>
@@ -38,10 +38,10 @@
             </form>
         </main>
         <footer>
-            <div class="sponsors">
-                <h3>Sponsorer</h3>
+            <details class="sponsors">
+                <summary>Sponsorer</summary>
                 <p>Plass til sponsorer.</p>
-            </div>
+            </details>
         </footer>
     </body>
 </html>

--- a/clients/baattilsyn/website/baattilsyn-website-v1/tjenester.html
+++ b/clients/baattilsyn/website/baattilsyn-website-v1/tjenester.html
@@ -12,8 +12,8 @@
     </head>
     <body>
         <header>
-            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" />
-            <img src="../../assets/logo.svg" alt="Båttilsyn logo" />
+            <img src="../../../../docs/assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
+            <img src="../../assets/logo.svg" alt="Båttilsyn logo" loading="lazy" />
         </header>
         <nav>
             <a href="index.html">Hjem</a>
@@ -45,10 +45,10 @@
             </section>
         </main>
         <footer>
-            <div class="sponsors">
-                <h3>Sponsorer</h3>
+            <details class="sponsors">
+                <summary>Sponsorer</summary>
                 <p>Plass til sponsorer.</p>
-            </div>
+            </details>
         </footer>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- enable `loading="lazy"` for images in Båttilsyn theme pages
- wrap sponsor sections in `<details>` to defer rendering

## Testing
- `npm run format` *(fails: price-per-item.js syntax error)*
- `npm run lint` *(fails: htmllint found errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889587d42048328bcef4ff46326ea85