### PR TITLE
Document asset cache headers

### DIFF
--- a/clients/comma/website/comma-website_v2/robots.txt
+++ b/clients/comma/website/comma-website_v2/robots.txt
@@ -2,3 +2,6 @@ User-agent: *
 Allow: /
 
 Sitemap: /sitemap.xml
+
+# Cache static JavaScript and CSS assets for one year
+Cache-Control: public, max-age=31536000

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,12 +12,14 @@ curl https://mise.run | sh
 ```
 
 Installer prosjektets avhengigheter:
+
 ```bash
 npm install
 ```
 
 Start utviklingsserveren:
-```bash
+
+````bash
 npm run dev
 Start et nytt terminalvindu eller følg installerens instruksjoner for å laste inn `mise`.
 
@@ -27,7 +29,7 @@ Kjør `mise install` for å hente Node.js og pnpm i riktig versjon:
 
 ```bash
 mise install
-```
+````
 
 ## 3. Installer prosjektavhengigheter
 
@@ -60,3 +62,17 @@ Tekstene for "Om oss" og "Kontakt oss" ligger i Shopify-temaet under `clients/ba
 Filene følger Shopifys JSON-struktur og inneholder også meta-felter for tittel og beskrivelse. Rediger dem direkte i git.
 
 Kjør `npm run lint` og `npm test` før du committer. Linting ekskluderer `.liquid` og `templates/*.json` via ignore-filene slik at temaet ikke påvirkes. Fargepalett og tone beskrives i [`docs/BRAND_GUIDE.md`](BRAND_GUIDE.md).
+
+## Anbefalt cacheoppsett
+
+For raske lastetider bør statiske filer i mappen `/assets/` caches lenge i nettleseren.
+Sett opp serveren eller Shopify-temaet slik at JavaScript- og CSS-filer leveres
+med en `Cache-Control`-header på opptil ett år:
+
+```
+/assets/*.js  Cache-Control: public, max-age=31536000
+/assets/*.css Cache-Control: public, max-age=31536000
+```
+
+Bruk filversjonering eller query-parametere ved endringer slik at oppdaterte
+filer lastes inn når innholdet endres.


### PR DESCRIPTION
## Summary
- set far-future caching header in sample `robots.txt`
- add recommended cache settings to SETUP guide

## Testing
- `npx prettier -w docs/SETUP.md`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889587db0e483289d84a56e3ad0bb08