### PR TITLE
Add sitemap and robots for baattilsyn

### DIFF
--- a/clients/baattilsyn/website/baattilsyn.no/robots.txt
+++ b/clients/baattilsyn/website/baattilsyn.no/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml

--- a/clients/baattilsyn/website/baattilsyn.no/sitemap.xml
+++ b/clients/baattilsyn/website/baattilsyn.no/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>/</loc>
+  </url>
+  <url>
+    <loc>/tjenester.html</loc>
+  </url>
+  <url>
+    <loc>/kontakt-oss.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add `robots.txt` and `sitemap.xml` for the baattilsyn static site

## Testing
- `npm install` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*
- `npm run format` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889623a6f048328843faff92bd10495