### PR TITLE
Add bundle size budgets

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,7 +2,17 @@
   "ci": {
     "collect": {
       "url": ["https://comma-records.com"],
-      "numberOfRuns": 1
+      "numberOfRuns": 1,
+      "settings": {
+        "budgets": [
+          {
+            "resourceSizes": [
+              { "resourceType": "script", "budget": 250 },
+              { "resourceType": "stylesheet", "budget": 250 }
+            ]
+          }
+        ]
+      }
     },
     "assert": {
       "assertions": {

--- a/package.backup.json
+++ b/package.backup.json
@@ -24,6 +24,7 @@
     "htmllint": "^0.7.3",
     "jest": "^29.0.0",
     "jsdom": "^22.0.0",
-    "stylelint": "^16.22.0"
+    "stylelint": "^16.22.0",
+    "webpack-bundle-analyzer": "^4.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "stylelint": "^16.22.0",
     "terser-webpack-plugin": "^5.3.14",
     "webpack": "^5.101.0",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "webpack-bundle-analyzer": "^4.10.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const glob = require('glob');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 const entries = {};
 // Grab all JS and CSS files in the assets folder
@@ -29,9 +30,19 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({ filename: '[name].min.css' }),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'disabled',
+      generateStatsFile: true,
+      statsFilename: 'bundle-stats.json'
+    }),
   ],
   optimization: {
     minimize: true,
     minimizer: [new TerserPlugin(), new CssMinimizerPlugin()],
+  },
+  performance: {
+    hints: 'error',
+    maxEntrypointSize: 250000,
+    maxAssetSize: 250000,
   },
 };


### PR DESCRIPTION
## Summary
- add Webpack Bundle Analyzer to enforce bundle size budgets
- document size limits via Lighthouse configuration

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68896243a8fc832887790b71adf3a75c