### PR TITLE
Update lighthouse workflow node version

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 18.20.8
       - name: Install dependencies
         run: npm install
       - name: Run Lighthouse CI


### PR DESCRIPTION
## Summary
- run lighthouse with Node 18.20.8

## Testing
- `npm install` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*
- `act pull_request -W .github/workflows/lighthouse.yml -j audit --dryrun` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_6889623525108328be524894d88485df