### PR TITLE
Fix alt text in v4 templates

### DIFF
--- a/clients/baattilsyn/website/website_v4/snippets/icon-with-text.liquid
+++ b/clients/baattilsyn/website/website_v4/snippets/icon-with-text.liquid
@@ -50,7 +50,7 @@
           {% if block.settings.image_1.alt != blank %}
             alt="{{ block.settings.image_1.alt | escape }}"
           {% else %}
-            role="presentation"
+            alt="{{ block.settings.heading_1 | escape }}"
           {% endif %}
           height="auto"
           width="auto"
@@ -72,7 +72,7 @@
           {% if block.settings.image_2.alt != blank %}
             alt="{{ block.settings.image_2.alt | escape }}"
           {% else %}
-            role="presentation"
+            alt="{{ block.settings.heading_2 | escape }}"
           {% endif %}
           height="auto"
           width="auto"
@@ -94,7 +94,7 @@
           {% if block.settings.image_3.alt != blank %}
             alt="{{ block.settings.image_3.alt | escape }}"
           {% else %}
-            role="presentation"
+            alt="{{ block.settings.heading_3 | escape }}"
           {% endif %}
           height="auto"
           width="auto"

--- a/clients/baattilsyn/website/website_v4/templates/gift_card.liquid
+++ b/clients/baattilsyn/website/website_v4/templates/gift_card.liquid
@@ -136,7 +136,7 @@
           <img
             class="gift-card__image"
             src="{{ 'gift-card/card.svg' | shopify_asset_url }}"
-            alt=""
+            alt="Gift card"
             height="{{ 570 | divided_by: 1.5 }}"
             width="570"
             loading="eager"


### PR DESCRIPTION
## Summary
- add alt to gift card image
- fallback to heading text for icon images when custom alt text missing

## Testing
- `npm run format:check` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68896237c8388328bbbfa9dc58e0805d