### PR TITLE
Add OG/Twitter meta snippet for Båttilsyn

### DIFF
--- a/clients/baattilsyn/pages/index.html
+++ b/clients/baattilsyn/pages/index.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="Båttilsyn - trygghet for båteiere" />
+        <!--#include file="snippets/meta-tags.html" -->
         <title>Båttilsyn | Hjem</title>
         <link rel="stylesheet" href="../styles/global.css" />
 </head>

--- a/clients/baattilsyn/pages/kontakt-oss.html
+++ b/clients/baattilsyn/pages/kontakt-oss.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="Kontakt oss" />
+        <!--#include file="snippets/meta-tags.html" -->
         <title>Båttilsyn | Kontakt oss</title>
         <link rel="stylesheet" href="../styles/global.css" />
 </head>

--- a/clients/baattilsyn/pages/snippets/meta-tags.html
+++ b/clients/baattilsyn/pages/snippets/meta-tags.html
@@ -1,0 +1,9 @@
+<!-- Reusable Open Graph and Twitter meta tags -->
+<meta property="og:title" content="{{TITLE}}" />
+<meta property="og:description" content="{{DESCRIPTION}}" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="/assets/og-default.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{TITLE}}" />
+<meta name="twitter:description" content="{{DESCRIPTION}}" />
+<meta name="twitter:image" content="/assets/og-default.jpg" />

--- a/clients/baattilsyn/pages/tjenester.html
+++ b/clients/baattilsyn/pages/tjenester.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="Våre tjenester" />
+        <!--#include file="snippets/meta-tags.html" -->
         <title>Båttilsyn | Tjenester</title>
         <link rel="stylesheet" href="../styles/global.css" />
 </head>

--- a/clients/baattilsyn/website/website_v4/snippets/meta-tags.liquid
+++ b/clients/baattilsyn/website/website_v4/snippets/meta-tags.liquid
@@ -1,8 +1,8 @@
 {%- liquid
-  assign og_title = page_title | default: shop.name
+  assign og_title = template.meta_title | default: page_title | default: shop.name
   assign og_url = canonical_url | default: request.origin
   assign og_type = 'website'
-  assign og_description = page_description | default: shop.description | default: shop.name
+  assign og_description = template.meta_description | default: page_description | default: shop.description | default: shop.name
 
   if request.page_type == 'product'
     assign og_type = 'product'


### PR DESCRIPTION
## Summary
- create reusable meta-tag snippet for static Båttilsyn pages
- reference new snippet from all HTML pages
- load meta_title/meta_description dynamically in Shopify snippet

## Testing
- `npm run lint` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68896238f134832882b20c68e90cf231