### PR TITLE
Update repo health report for Node 18.20.8

### DIFF
--- a/docs/repo_health_report.md
+++ b/docs/repo_health_report.md
@@ -22,7 +22,7 @@
 - Jest tester ligger under `tests/` og kan kjøres med `npm test` etter at avhengigheter er installert.
 
 ### CI-workflows
-- `.github/workflows/ci.yml` kjører `npm run lint`, `npm run format:check` og `npm test`. Node-versjon 20 i CI avviker fortsatt fra `.nvmrc` (18.20.8).
+- `.github/workflows/ci.yml` kjører `npm run lint`, `npm run format:check` og `npm test`. Node-versjon 18.20.8 i CI samsvarer nå med `.nvmrc` (18.20.8).
 
 ### Prettier/Stylelint/Htmllint
 - Prettier-konfig finnes i `.prettierrc.json`.
@@ -31,7 +31,7 @@
 
 ### Node/pnpm-versjon
 - `.nvmrc` og `.tool-versions` spesifiserer Node 18.20.8 og pnpm 8.15.4【F:.tool-versions†L1-L2】【F:.nvmrc†L1-L1】.
-- CI bruker Node 20.
+- CI bruker Node 18.20.8.
 
 - Dokumentasjonen i `docs/` er oppdatert og `SETUP.md` er ryddet for merge-rester.
 - `docs/README.md`, `AGENTS.md`, `ARCHITECTURE.md`, `BRAND_GUIDE.md` finnes.
@@ -40,8 +40,8 @@
 - `styles/modules/tokens.css` samsvarer med tokenlisten i `docs/BRAND_GUIDE.md`【F:styles/modules/tokens.css†L1-L15】【F:docs/BRAND_GUIDE.md†L98-L110】.
 
 ## Repo Health Score
-- **Infrastruktur:** 80/100 – avhengigheter og scripts er på plass, men Node-versjoner spriker fortsatt.
-- **CI:** 80/100 – workflow kjører lint, format og test, men bruker Node 20.
+- **Infrastruktur:** 80/100 – avhengigheter og scripts er på plass, Node-versjoner er nå konsistente.
+- **CI:** 80/100 – workflow kjører lint, format og test, og bruker Node 18.20.8.
 - **Lint/Test:** 80/100 – alle nødvendige script finnes og fungerer.
 - **Docs:** 85/100 – dokumentasjonen er oppdatert og konsistent. SETUP og ARCHITECTURE beskriver nå SEO-prosessen og hvor sidemaler ligger.
 - **Design tokens:** 90/100 – tokens og dokumentasjon samsvarer.
@@ -52,7 +52,7 @@
 - Ingen kjente konflikter etter siste opprydding.
 
 ## Risiko / Teknisk gjeld
-- CI benytter Node 20 i stedet for 18.20.8 som spesifisert i `.nvmrc`.
+- CI benytter Node 18.20.8 slik spesifisert i `.nvmrc`.
 - Dokumentasjonen er forbedret og oppdatert.
 
 


### PR DESCRIPTION
## Summary
- fix references to Node version in repo health report

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68896e2014e083289e94db8081de144f