### PR TITLE
feat(next): add page titles and descriptions

### DIFF
--- a/next/pages/about.tsx
+++ b/next/pages/about.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
+import Head from 'next/head';
 
 export default function About() {
   return (
-    <main>
-      <h1>Om oss</h1>
-      <p>Dette er en forenklet Next.js-versjon av B\u00e5ttilsyn.</p>
-    </main>
+    <>
+      <Head>
+        <title>B\u00e5ttilsyn Next.js - Om oss</title>
+        <meta
+          name="description"
+          content="Informasjon om B\u00e5ttilsyn Next.js"
+        />
+      </Head>
+      <main>
+        <h1>Om oss</h1>
+        <p>Dette er en forenklet Next.js-versjon av B\u00e5ttilsyn.</p>
+      </main>
+    </>
   );
 }

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic';
 import React from 'react';
+import Head from 'next/head';
 
 const HeavyModule = dynamic(() => import('../components/HeavyModule'), {
   loading: () => <p>Loading module...</p>,
@@ -8,9 +9,18 @@ const HeavyModule = dynamic(() => import('../components/HeavyModule'), {
 
 export default function Home() {
   return (
-    <main>
-      <h1>B\u00e5ttilsyn Next.js</h1>
-      <HeavyModule />
-    </main>
+    <>
+      <Head>
+        <title>B\u00e5ttilsyn Next.js - Home</title>
+        <meta
+          name="description"
+          content="B\u00e5ttilsyn Next.js example home page"
+        />
+      </Head>
+      <main>
+        <h1>B\u00e5ttilsyn Next.js</h1>
+        <HeavyModule />
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add `<Head>` metadata to Next.js pages

## Testing
- `npm install`
- `npm run lint` *(fails: 1170 errors)*
- `npm run format` *(fails on docs JS file)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896e5116148328a62cb2828df69120