### PR TITLE
Refactor Shopify scripts as modules

### DIFF
--- a/docs/website/website-v1/assets/cart-notification.js
+++ b/docs/website/website-v1/assets/cart-notification.js
@@ -80,4 +80,17 @@ class CartNotification extends HTMLElement {
   }
 }
 
-customElements.define('cart-notification', CartNotification);
+function register() {
+  if (
+    typeof customElements !== 'undefined' &&
+    !customElements.get('cart-notification')
+  ) {
+    customElements.define('cart-notification', CartNotification);
+  }
+}
+
+if (typeof customElements !== 'undefined') {
+  register();
+}
+
+module.exports = CartNotification;

--- a/docs/website/website-v1/assets/cart.js
+++ b/docs/website/website-v1/assets/cart.js
@@ -10,7 +10,6 @@ class CartRemoveButton extends HTMLElement {
   }
 }
 
-customElements.define('cart-remove-button', CartRemoveButton);
 
 class CartItems extends HTMLElement {
   constructor() {
@@ -276,24 +275,33 @@ class CartItems extends HTMLElement {
   }
 }
 
-customElements.define('cart-items', CartItems);
-
-if (!customElements.get('cart-note')) {
-  customElements.define(
-    'cart-note',
-    class CartNote extends HTMLElement {
-      constructor() {
-        super();
-
-        this.addEventListener(
-          'input',
-          debounce((event) => {
-            const body = JSON.stringify({ note: event.target.value });
-            fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
-              .then(() => CartPerformance.measureFromEvent('note-update:user-action', event));
-          }, ON_CHANGE_DEBOUNCE_TIMER)
-        );
+if (typeof customElements !== 'undefined') {
+  if (!customElements.get('cart-remove-button')) {
+    customElements.define('cart-remove-button', CartRemoveButton);
+  }
+  if (!customElements.get('cart-items')) {
+    customElements.define('cart-items', CartItems);
+  }
+  if (!customElements.get('cart-note')) {
+    customElements.define(
+      'cart-note',
+      class CartNote extends HTMLElement {
+        constructor() {
+          super();
+          this.addEventListener(
+            'input',
+            debounce((event) => {
+              const body = JSON.stringify({ note: event.target.value });
+              fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
+                .then(() =>
+                  CartPerformance.measureFromEvent('note-update:user-action', event)
+                );
+            }, ON_CHANGE_DEBOUNCE_TIMER)
+          );
+        }
       }
-    }
-  );
+    );
+  }
 }
+
+module.exports = { CartRemoveButton, CartItems };

--- a/docs/website/website-v1/assets/quick-add-bulk.js
+++ b/docs/website/website-v1/assets/quick-add-bulk.js
@@ -1,201 +1,209 @@
-if (!customElements.get('quick-add-bulk')) {
-  customElements.define(
-    'quick-add-bulk',
-    class QuickAddBulk extends BulkAdd {
-      constructor() {
-        super();
-        this.quantity = this.querySelector('quantity-input');
+class QuickAddBulk extends BulkAdd {
+  constructor() {
+    super();
+    this.quantity = this.querySelector('quantity-input');
 
-        const debouncedOnChange = debounce((event) => {
-          if (parseInt(event.target.value) === 0) {
-            this.startQueue(event.target.dataset.index, parseInt(event.target.value));
-          } else {
-            this.validateQuantity(event);
-          }
-        }, ON_CHANGE_DEBOUNCE_TIMER);
-
-        this.addEventListener('change', debouncedOnChange.bind(this));
-        this.listenForActiveInput();
-        this.listenForKeydown();
-        this.lastActiveInputId = null;
+    const debouncedOnChange = debounce((event) => {
+      if (parseInt(event.target.value) === 0) {
+        this.startQueue(event.target.dataset.index, parseInt(event.target.value));
+      } else {
+        this.validateQuantity(event);
       }
+    }, ON_CHANGE_DEBOUNCE_TIMER);
 
-      connectedCallback() {
-        if (typeof globalThis.subscribe === 'function') {
-          this.cartUpdateUnsubscriber = globalThis.subscribe(
-            PUB_SUB_EVENTS.cartUpdate,
-            (event) => {
-            if (
-              event.source === 'quick-add' ||
-              (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||
-              (event.cartData.variant_id && !(event.cartData.variant_id === parseInt(this.dataset.index)))
-            ) {
-              return;
-            }
-            // If its another section that made the update
-            this.onCartUpdate().then(() => {
-              this.listenForActiveInput();
-              this.listenForKeydown();
-            });
+    this.addEventListener('change', debouncedOnChange.bind(this));
+    this.listenForActiveInput();
+    this.listenForKeydown();
+    this.lastActiveInputId = null;
+  }
+
+  connectedCallback() {
+    if (typeof globalThis.subscribe === 'function') {
+      this.cartUpdateUnsubscriber = globalThis.subscribe(
+        PUB_SUB_EVENTS.cartUpdate,
+        (event) => {
+          if (
+            event.source === 'quick-add' ||
+            (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||
+            (event.cartData.variant_id && !(event.cartData.variant_id === parseInt(this.dataset.index)))
+          ) {
+            return;
+          }
+          // If its another section that made the update
+          this.onCartUpdate().then(() => {
+            this.listenForActiveInput();
+            this.listenForKeydown();
           });
         }
-      }
+      );
+    }
+  }
 
-      disconnectedCallback() {
-        if (this.cartUpdateUnsubscriber) {
-          this.cartUpdateUnsubscriber();
-        }
-      }
+  disconnectedCallback() {
+    if (this.cartUpdateUnsubscriber) {
+      this.cartUpdateUnsubscriber();
+    }
+  }
 
-      get input() {
-        return this.querySelector('quantity-input input');
-      }
+  get input() {
+    return this.querySelector('quantity-input input');
+  }
 
-      selectProgressBar() {
-        return this.querySelector('.progress-bar-container');
-      }
+  selectProgressBar() {
+    return this.querySelector('.progress-bar-container');
+  }
 
-      listenForActiveInput() {
-        if (!this.classList.contains('hidden')) {
-          this.input?.addEventListener('focusin', (event) => event.target.select());
-        }
-        this.isEnterPressed = false;
-      }
+  listenForActiveInput() {
+    if (!this.classList.contains('hidden')) {
+      this.input?.addEventListener('focusin', (event) => event.target.select());
+    }
+    this.isEnterPressed = false;
+  }
 
-      listenForKeydown() {
-        this.input?.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter') {
-            this.input?.blur();
-            this.isEnterPressed = true;
+  listenForKeydown() {
+    this.input?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        this.input?.blur();
+        this.isEnterPressed = true;
+      }
+    });
+  }
+
+  cleanErrorMessageOnType(event) {
+    event.target.addEventListener(
+      'keypress',
+      () => {
+        event.target.setCustomValidity('');
+      },
+      { once: true }
+    );
+  }
+
+  get sectionId() {
+    if (!this._sectionId) {
+      this._sectionId = this.closest('.collection-quick-add-bulk').dataset.id;
+    }
+
+    return this._sectionId;
+  }
+
+  onCartUpdate() {
+    return new Promise((resolve, reject) => {
+      fetch(`${this.getSectionsUrl()}?section_id=${this.sectionId}`)
+        .then((response) => response.text())
+        .then((responseText) => {
+          const html = new DOMParser().parseFromString(responseText, 'text/html');
+          const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
+          if (sourceQty) {
+            this.innerHTML = sourceQty.innerHTML;
           }
+          resolve();
+        })
+        .catch((e) => {
+          console.error(e);
+          reject(e);
         });
-      }
+    });
+  }
 
-      cleanErrorMessageOnType(event) {
-        event.target.addEventListener(
-          'keypress',
-          () => {
-            event.target.setCustomValidity('');
-          },
-          { once: true }
+  getSectionsUrl() {
+    const pageParams = new URLSearchParams(window.location.search);
+    const pageNumber = decodeURIComponent(pageParams.get('page') || '');
+
+    return `${window.location.pathname}${pageNumber ? `?page=${pageNumber}` : ''}`;
+  }
+
+  updateMultipleQty(items) {
+    this.selectProgressBar().classList.remove('hidden');
+
+    const ids = Object.keys(items);
+    const body = JSON.stringify({
+      updates: items,
+      sections: this.getSectionsToRender().map((section) => section.section),
+      sections_url: this.getSectionsUrl(),
+    });
+
+    fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
+      .then((response) => {
+        return response.text();
+      })
+      .then((state) => {
+        const parsedState = JSON.parse(state);
+        this.renderSections(parsedState, ids);
+        publish(PUB_SUB_EVENTS.cartUpdate, { source: 'quick-add', cartData: parsedState });
+      })
+      .catch(() => {
+        // Commented out for now and will be fixed when BE issue is done https://github.com/Shopify/shopify/issues/440605
+        // e.target.setCustomValidity(error);
+        // e.target.reportValidity();
+        // this.resetQuantityInput(ids[index]);
+        // this.selectProgressBar().classList.add('hidden');
+        // e.target.select();
+        // this.cleanErrorMessageOnType(e);
+      })
+      .finally(() => {
+        this.selectProgressBar().classList.add('hidden');
+        this.setRequestStarted(false);
+      });
+  }
+
+  getSectionsToRender() {
+    return [
+      {
+        id: `quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
+        section: this.sectionId,
+        selector: `#quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
+      },
+      {
+        id: 'cart-icon-bubble',
+        section: 'cart-icon-bubble',
+        selector: '.shopify-section',
+      },
+      {
+        id: 'CartDrawer',
+        selector: '.drawer__inner',
+        section: 'cart-drawer',
+      },
+    ];
+  }
+
+  renderSections(parsedState, ids) {
+    const intersection = this.queue.filter((element) => ids.includes(element.id));
+    if (intersection.length !== 0) return;
+    this.getSectionsToRender().forEach((section) => {
+      const sectionElement = document.getElementById(section.id);
+      if (section.section === 'cart-drawer') {
+        sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', parsedState.items.length === 0);
+      }
+      const elementToReplace =
+        sectionElement && sectionElement.querySelector(section.selector)
+          ? sectionElement.querySelector(section.selector)
+          : sectionElement;
+      if (elementToReplace) {
+        elementToReplace.innerHTML = this.getSectionInnerHTML(
+          parsedState.sections[section.section],
+          section.selector
         );
       }
+    });
 
-      get sectionId() {
-        if (!this._sectionId) {
-          this._sectionId = this.closest('.collection-quick-add-bulk').dataset.id;
-        }
-
-        return this._sectionId;
-      }
-
-      onCartUpdate() {
-        return new Promise((resolve, reject) => {
-          fetch(`${this.getSectionsUrl()}?section_id=${this.sectionId}`)
-            .then((response) => response.text())
-            .then((responseText) => {
-              const html = new DOMParser().parseFromString(responseText, 'text/html');
-              const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
-              if (sourceQty) {
-                this.innerHTML = sourceQty.innerHTML;
-              }
-              resolve();
-            })
-            .catch((e) => {
-              console.error(e);
-              reject(e);
-            });
-        });
-      }
-
-      getSectionsUrl() {
-        const pageParams = new URLSearchParams(window.location.search);
-        const pageNumber = decodeURIComponent(pageParams.get('page') || '');
-
-        return `${window.location.pathname}${pageNumber ? `?page=${pageNumber}` : ''}`;
-      }
-
-      updateMultipleQty(items) {
-        this.selectProgressBar().classList.remove('hidden');
-
-        const ids = Object.keys(items);
-        const body = JSON.stringify({
-          updates: items,
-          sections: this.getSectionsToRender().map((section) => section.section),
-          sections_url: this.getSectionsUrl(),
-        });
-
-        fetch(`${routes.cart_update_url}`, { ...fetchConfig(), ...{ body } })
-          .then((response) => {
-            return response.text();
-          })
-          .then((state) => {
-            const parsedState = JSON.parse(state);
-            this.renderSections(parsedState, ids);
-            publish(PUB_SUB_EVENTS.cartUpdate, { source: 'quick-add', cartData: parsedState });
-          })
-          .catch(() => {
-            // Commented out for now and will be fixed when BE issue is done https://github.com/Shopify/shopify/issues/440605
-            // e.target.setCustomValidity(error);
-            // e.target.reportValidity();
-            // this.resetQuantityInput(ids[index]);
-            // this.selectProgressBar().classList.add('hidden');
-            // e.target.select();
-            // this.cleanErrorMessageOnType(e);
-          })
-          .finally(() => {
-            this.selectProgressBar().classList.add('hidden');
-            this.setRequestStarted(false);
-          });
-      }
-
-      getSectionsToRender() {
-        return [
-          {
-            id: `quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
-            section: this.sectionId,
-            selector: `#quick-add-bulk-${this.dataset.index}-${this.sectionId}`,
-          },
-          {
-            id: 'cart-icon-bubble',
-            section: 'cart-icon-bubble',
-            selector: '.shopify-section',
-          },
-          {
-            id: 'CartDrawer',
-            selector: '.drawer__inner',
-            section: 'cart-drawer',
-          },
-        ];
-      }
-
-      renderSections(parsedState, ids) {
-        const intersection = this.queue.filter((element) => ids.includes(element.id));
-        if (intersection.length !== 0) return;
-        this.getSectionsToRender().forEach((section) => {
-          const sectionElement = document.getElementById(section.id);
-          if (section.section === 'cart-drawer') {
-            sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', parsedState.items.length === 0);
-          }
-          const elementToReplace =
-            sectionElement && sectionElement.querySelector(section.selector)
-              ? sectionElement.querySelector(section.selector)
-              : sectionElement;
-          if (elementToReplace) {
-            elementToReplace.innerHTML = this.getSectionInnerHTML(
-              parsedState.sections[section.section],
-              section.selector
-            );
-          }
-        });
-
-        if (this.isEnterPressed) {
-          this.querySelector(`#Quantity-${this.lastActiveInputId}`).select();
-        }
-
-        this.listenForActiveInput();
-        this.listenForKeydown();
-      }
+    if (this.isEnterPressed) {
+      this.querySelector(`#Quantity-${this.lastActiveInputId}`).select();
     }
-  );
+
+    this.listenForActiveInput();
+    this.listenForKeydown();
+  }
 }
+
+function register() {
+  if (typeof customElements !== 'undefined' && !customElements.get('quick-add-bulk')) {
+    customElements.define('quick-add-bulk', QuickAddBulk);
+  }
+}
+
+if (typeof customElements !== 'undefined') {
+  register();
+}
+
+module.exports = QuickAddBulk;

--- a/docs/website/website-v1/assets/search-form.js
+++ b/docs/website/website-v1/assets/search-form.js
@@ -44,4 +44,17 @@ class SearchForm extends HTMLElement {
   }
 }
 
-customElements.define('search-form', SearchForm);
+function register() {
+  if (
+    typeof customElements !== 'undefined' &&
+    !customElements.get('search-form')
+  ) {
+    customElements.define('search-form', SearchForm);
+  }
+}
+
+if (typeof customElements !== 'undefined') {
+  register();
+}
+
+module.exports = SearchForm;

--- a/tests/cart-notification.test.js
+++ b/tests/cart-notification.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
@@ -17,10 +16,11 @@ describe('CartNotification.getSectionInnerHTML', () => {
     global.trapFocus = jest.fn();
     global.removeTrapFocus = jest.fn();
 
-    const scriptPath = path.resolve(__dirname, '../docs/website/website-v1/assets/cart-notification.js');
-    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-    window.Function(scriptContent).call(window);
-    CartNotification = window.customElements.get('cart-notification');
+    const scriptPath = path.resolve(
+      __dirname,
+      '../docs/website/website-v1/assets/cart-notification.js'
+    );
+    CartNotification = require(scriptPath);
     instance = new CartNotification();
     document.body.appendChild(instance);
   });

--- a/tests/cart.test.js
+++ b/tests/cart.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
@@ -23,10 +22,12 @@ describe('CartItems.getSectionInnerHTML', () => {
     global.publish = jest.fn();
     global.PUB_SUB_EVENTS = { cartUpdate: 'cart-update' };
 
-    const scriptPath = path.resolve(__dirname, '../docs/website/website-v1/assets/cart.js');
-    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-    window.Function(scriptContent).call(window);
-    CartItems = window.customElements.get('cart-items');
+    const scriptPath = path.resolve(
+      __dirname,
+      '../docs/website/website-v1/assets/cart.js'
+    );
+    const cartModule = require(scriptPath);
+    CartItems = cartModule.CartItems || cartModule;
     instance = new CartItems();
     document.body.appendChild(instance);
   });

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
@@ -43,8 +42,7 @@ describe('QuickAddBulk.renderSections', () => {
       '../docs/website/website-v1/assets/quick-add-bulk.js'
     );
     delete require.cache[require.resolve(scriptPath)];
-    require(scriptPath);
-    QuickAddBulk = window.customElements.get('quick-add-bulk');
+    QuickAddBulk = require(scriptPath);
     instance = new QuickAddBulk();
     document.body.appendChild(instance);
     instance.dataset.index = '1';

--- a/tests/search-form.test.js
+++ b/tests/search-form.test.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
@@ -19,15 +18,16 @@ describe('SearchForm component', () => {
       __dirname,
       '../docs/website/website-v1/assets/search-form.js'
     );
-    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
-    window.Function(scriptContent).call(window);
-    SearchForm = window.customElements.get('search-form');
+    SearchForm = require(scriptPath);
 
-    const wrapper = document.createElement('div');
-    wrapper.innerHTML =
-      '<form><search-form><input type="search"><button type="reset" class="hidden"></button></search-form></form>';
-    document.body.appendChild(wrapper.firstElementChild);
-    instance = document.querySelector('search-form');
+    const form = document.createElement('form');
+    instance = new SearchForm();
+    instance.innerHTML =
+      '<input type="search"><button type="reset" class="hidden"></button>';
+    instance.input = instance.querySelector('input[type="search"]');
+    instance.resetButton = instance.querySelector('button[type="reset"]');
+    form.appendChild(instance);
+    document.body.appendChild(form);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- convert Shopify theme scripts to CommonJS modules
- load theme modules directly in unit tests
- stub globals for custom element tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889decadf8c8328abd5fd78b414a302