### PR TITLE
Sanitize HTML for cart updates

### DIFF
--- a/docs/website/website-v1/assets/quick-add-bulk.js
+++ b/docs/website/website-v1/assets/quick-add-bulk.js
@@ -1,3 +1,7 @@
+const createDOMPurify = require('dompurify');
+
+const DOMPurify = createDOMPurify(window);
+
 class QuickAddBulk extends BulkAdd {
   constructor() {
     super();
@@ -95,7 +99,10 @@ class QuickAddBulk extends BulkAdd {
           const html = new DOMParser().parseFromString(responseText, 'text/html');
           const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
           if (sourceQty) {
-            this.innerHTML = sourceQty.innerHTML;
+            const sanitized = DOMPurify.sanitize(sourceQty.innerHTML);
+            if (this.innerHTML !== sanitized) {
+              this.innerHTML = sanitized;
+            }
           }
           resolve();
         })
@@ -180,10 +187,15 @@ class QuickAddBulk extends BulkAdd {
           ? sectionElement.querySelector(section.selector)
           : sectionElement;
       if (elementToReplace) {
-        elementToReplace.innerHTML = this.getSectionInnerHTML(
-          parsedState.sections[section.section],
-          section.selector
+        const newHtml = DOMPurify.sanitize(
+          this.getSectionInnerHTML(
+            parsedState.sections[section.section],
+            section.selector
+          )
         );
+        if (elementToReplace.innerHTML !== newHtml) {
+          elementToReplace.innerHTML = newHtml;
+        }
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^14.2.1",
         "css-loader": "^7.1.2",
         "css-minimizer-webpack-plugin": "^7.0.2",
+        "dompurify": "^3.2.6",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
         "glob": "^11.0.3",
@@ -3608,6 +3609,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -6020,6 +6029,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "@testing-library/react": "^14.2.1",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.2",
-    "glob": "^11.0.3",
+    "dompurify": "^3.2.6",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
+    "glob": "^11.0.3",
     "htmllint": "^0.7.3",
     "htmllint-cli": "^0.0.6",
     "husky": "^9.1.7",
@@ -38,7 +39,7 @@
     "stylelint": "^16.22.0",
     "terser-webpack-plugin": "^5.3.14",
     "webpack": "^5.101.0",
-    "webpack-cli": "^6.0.1",
-    "webpack-bundle-analyzer": "^4.10.1"
+    "webpack-bundle-analyzer": "^4.10.1",
+    "webpack-cli": "^6.0.1"
   }
 }

--- a/tests/cart.test.js
+++ b/tests/cart.test.js
@@ -52,4 +52,9 @@ describe('CartItems.getSectionInnerHTML', () => {
     const html = '<div><span class="target">hello</span></div>';
     expect(instance.getSectionInnerHTML(html, '.target')).toBe('hello');
   });
+
+  test('strips script tags from HTML', () => {
+    const html = '<div><span class="target">hi<script>alert(1)</script></span></div>';
+    expect(instance.getSectionInnerHTML(html, '.target')).toBe('hi');
+  });
 });

--- a/tests/quick-add-bulk.test.js
+++ b/tests/quick-add-bulk.test.js
@@ -71,4 +71,17 @@ describe('QuickAddBulk.renderSections', () => {
     instance.renderSections(parsedState, []);
     expect(cartDrawer.classList.contains('is-empty')).toBe(true);
   });
+
+  test('sanitizes section HTML before rendering', () => {
+    document.getElementById('cart-icon-bubble').innerHTML = '<div class="shopify-section"></div>';
+    instance.getSectionsToRender = () => [
+      { id: 'cart-icon-bubble', section: 'cart-icon-bubble', selector: '.shopify-section' },
+    ];
+    const parsedState = {
+      items: [],
+      sections: { 'cart-icon-bubble': '<div class="shopify-section">test<script>alert(1)</script></div>' },
+    };
+    instance.renderSections(parsedState, []);
+    expect(document.querySelector('#cart-icon-bubble .shopify-section').innerHTML).toBe('test');
+  });
 });


### PR DESCRIPTION
## Summary
- sanitize HTML with DOMPurify before injecting into cart and quick-add elements
- avoid redundant DOM updates
- add tests checking malicious markup stripping
- include dompurify dev dependency

## Testing
- `npm test`
- `npm run lint` *(fails: 2823 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889e0d0a7408328a33e716ac9cb4721