### PR TITLE
Remove unused require

### DIFF
--- a/tools/optimize-images.js
+++ b/tools/optimize-images.js
@@ -1,6 +1,5 @@
 const glob = require('glob');
 const sharp = require('sharp');
-const path = require('path');
 
 const files = glob.sync('clients/**/assets/**/*.{png,jpg,jpeg}', { nodir: true });
 


### PR DESCRIPTION
## Summary
- remove unused `path` import from optimize images script
- run eslint to confirm no new lint errors

## Testing
- `npm run lint` *(fails: 2822 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889f3e6be4483288abac4a4238450e1