### PR TITLE
Add typed props to Next demo

### DIFF
--- a/next/components/HeavyModule.tsx
+++ b/next/components/HeavyModule.tsx
@@ -1,7 +1,17 @@
-const HeavyModule = () => {
+import React from 'react';
+
+export interface HeavyModuleProps {
+  /**
+   * Text displayed inside the component. This allows pages to
+   * customise the message while keeping the component strongly typed.
+   */
+  content: string;
+}
+
+const HeavyModule: React.FC<HeavyModuleProps> = ({ content }) => {
   return (
     <div>
-      <p>This module could load large libraries like charts or PDF viewers.</p>
+      <p>{content}</p>
     </div>
   );
 };

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -1,11 +1,15 @@
 import dynamic from 'next/dynamic';
 import React from 'react';
 import Head from 'next/head';
+import type { HeavyModuleProps } from '../components/HeavyModule';
 
-const HeavyModule = dynamic(() => import('../components/HeavyModule'), {
-  loading: () => <p>Loading module...</p>,
-  ssr: false,
-});
+const HeavyModule = dynamic<HeavyModuleProps>(
+  () => import('../components/HeavyModule'),
+  {
+    loading: () => <p>Loading module...</p>,
+    ssr: false,
+  }
+);
 
 export default function Home() {
   return (
@@ -19,7 +23,7 @@ export default function Home() {
       </Head>
       <main>
         <h1>B\u00e5ttilsyn Next.js</h1>
-        <HeavyModule />
+        <HeavyModule content="This module could load large libraries like charts or PDF viewers." />
       </main>
     </>
   );


### PR DESCRIPTION
## Summary
- type HeavyModule props
- pass props to HeavyModule in index page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fa26e1d88328ae52c206d69ee02a