### PR TITLE
Add tests and update status report

### DIFF
--- a/docs/repository-status-report.md
+++ b/docs/repository-status-report.md
@@ -20,3 +20,14 @@
 - `clients/comma/deliverables/`
 - `clients/comma/design/`
 - `clients/comma/meetings/`
+
+## Website Assets Overview
+
+There are 32 JavaScript modules under `docs/website/website-v1/assets`. Prior to
+this update only four of them had automated tests. Additional Jest tests now
+cover `details-modal.js` and `pubsub.js`, but most modules remain untested.
+
+Attempting to run `npm run build` followed by `npx webpack-bundle-analyzer
+dist/assets/bundle-stats.json` failed in this environment because webpack and its
+dependencies were not installed. Bundle size information could therefore not be
+generated.

--- a/tests/details-modal.test.js
+++ b/tests/details-modal.test.js
@@ -1,0 +1,54 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('DetailsModal custom element', () => {
+  let window, document, DetailsModal, instance;
+
+  beforeEach(() => {
+    const html = `<!DOCTYPE html>
+<details-modal>
+  <details>
+    <summary></summary>
+    <div tabindex="-1"><input></div>
+    <button type="button"></button>
+  </details>
+</details-modal>`;
+    const dom = new JSDOM(html);
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+    global.HTMLElement = window.HTMLElement;
+    global.customElements = window.customElements;
+    global.trapFocus = jest.fn();
+    global.removeTrapFocus = jest.fn();
+
+    const scriptPath = path.resolve(__dirname, '../docs/website/website-v1/assets/details-modal.js');
+    delete require.cache[require.resolve(scriptPath)];
+    require(scriptPath);
+    DetailsModal = window.customElements.get('details-modal');
+    instance = document.querySelector('details-modal');
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.customElements;
+    delete global.trapFocus;
+    delete global.removeTrapFocus;
+  });
+
+  test('isOpen reflects open attribute', () => {
+    expect(instance.isOpen()).toBe(false);
+    instance.open({ target: instance.summaryToggle });
+    expect(instance.isOpen()).toBe(true);
+  });
+
+  test('close removes open attribute', () => {
+    instance.open({ target: instance.summaryToggle });
+    instance.close();
+    expect(instance.isOpen()).toBe(false);
+  });
+});

--- a/tests/pubsub.test.js
+++ b/tests/pubsub.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('pubsub module', () => {
+  let subscribe, publish, window;
+
+  beforeEach(() => {
+    const dom = new JSDOM('<!DOCTYPE html>');
+    window = dom.window;
+    const scriptPath = path.resolve(__dirname, '../docs/website/website-v1/assets/pubsub.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.Function(scriptContent).call(window);
+    subscribe = window.subscribe;
+    publish = window.publish;
+  });
+
+  test('subscribe and publish events', async () => {
+    const cb = jest.fn();
+    const unsubscribe = subscribe('test', cb);
+    await publish('test', 1);
+    expect(cb).toHaveBeenCalledWith(1);
+    unsubscribe();
+    await publish('test', 2);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for `details-modal.js` and `pubsub.js`
- document assets test coverage and bundle analyzer attempt in `repository-status-report.md`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: webpack not found)*
- `npx webpack-bundle-analyzer dist/assets/bundle-stats.json` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889fb46d898832886be0ddc8d282d15