### PR TITLE
Add ESLint ignores and fix test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+clients/**/website/**
+docs/website/**
+dist/
+build/

--- a/tests/details-modal.test.js
+++ b/tests/details-modal.test.js
@@ -1,9 +1,8 @@
-const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
 describe('DetailsModal custom element', () => {
-  let window, document, DetailsModal, instance;
+  let window, document, instance;
 
   beforeEach(() => {
     const html = `<!DOCTYPE html>
@@ -27,7 +26,7 @@ describe('DetailsModal custom element', () => {
     const scriptPath = path.resolve(__dirname, '../docs/website/website-v1/assets/details-modal.js');
     delete require.cache[require.resolve(scriptPath)];
     require(scriptPath);
-    DetailsModal = window.customElements.get('details-modal');
+
     instance = document.querySelector('details-modal');
   });
 


### PR DESCRIPTION
## Summary
- add repository-level `.eslintignore` file
- clean up unused imports in `details-modal` test
- reference the test's custom element instance directly

## Testing
- `npm run lint` *(fails: htmllint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a13c696c48328b06f40bde2d2bdf9