### PR TITLE
Update docs for theme folder move

### DIFF
--- a/clients/baattilsyn/README.md
+++ b/clients/baattilsyn/README.md
@@ -1,8 +1,8 @@
 # baattilsyn.no
 
 Dette prosjektet inneholder alle filer til nettsiden **baattilsyn.no**.
-Versjon 2 av nettstedet ligger i mappen `website/baattilsyn.no/` og består av
-rene HTML-sider. Den tidligere utgaven ligger i `website/baattilsyn-website-v1/`.
+Nettsiden ligger nå i `themes/baattilsyn/website/baattilsyn.no/` og består av
+rene HTML-sider. Den tidligere utgaven finnes i `themes/website-v1`.
 
 ```
 clients/baattilsyn/
@@ -10,10 +10,10 @@ clients/baattilsyn/
 ├── deliverables/
 ├── design/
 ├── meetings/
-├── strategy/
-└── website/
-    ├── baattilsyn.no/            # gjeldende nettside (website_v2)
-    └── baattilsyn-website-v1/    # tidligere versjon
+└── strategy/
+```
+
+Nettstedskoden ligger i `themes/baattilsyn/website/baattilsyn.no/`.
 ```
 
 ## Lokalt oppsett
@@ -22,10 +22,10 @@ Installer avhengigheter og start en enkel server for forhåndsvisning:
 
 ```bash
 npm install         # første gang
-npx http-server website/baattilsyn.no
+npx http-server themes/baattilsyn/website/baattilsyn.no
 ```
 
-## Innhold i `website/baattilsyn.no`
+## Innhold i `themes/baattilsyn/website/baattilsyn.no`
 
 - `index.html`
 - `tjenester.html`

--- a/clients/comma/BRAND_GUIDE.md
+++ b/clients/comma/BRAND_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## 1. Logo og bruk
 - Logo-filer ligger under `brand-assets/logo/`.
-- Anbefalt plassering i nettsiden: `website/comma-website_v2/assets/`.
+- Anbefalt plassering i nettsiden: `themes/comma/website/comma-website_v2/assets/`.
 - Hold minst 24 px klaring rundt logoen for god lesbarhet.
 - Negativ/positiv bruk avhenger av fremtidig design; ingen fargeversjoner definert.
 

--- a/clients/comma/README.md
+++ b/clients/comma/README.md
@@ -17,7 +17,8 @@ This directory contains all operational documents, assets and website code for *
 - **sales-integrations/** – configurations for e‑commerce channels
 - **seo/** – keyword research and metadata templates
 - **strategy/** – roadmaps and overall project planning
-- **website/** – source code for comma-records.com
+-
+Website code is stored in `themes/comma/website/comma-website_v2/`.
 
 ## Maintainers
 The COMMA. core team maintains this folder with assistance from Nesheim & Vatten Consulting. See [../TASKS.md](TASKS.md) for active work items.

--- a/clients/nome-ror-as/README.md
+++ b/clients/nome-ror-as/README.md
@@ -6,5 +6,6 @@ This folder contains project materials for the Nome Rør AS client. Use the subf
 - **meetings/** – meeting agendas and notes
 - **strategy/** – planning and goal documentation
 - **design/** – design files, logo assets and graphics
-- **website/** – website code and configuration
- - **deliverables/** – archived under `../../archive/nome-ror-as/deliverables`
+- **deliverables/** – archived under `../../archive/nome-ror-as/deliverables`
+
+Website code lives in `themes/nome-ror-as/website/nome-theme-code_FINAL/`.

--- a/clients/to-ellis/README.md
+++ b/clients/to-ellis/README.md
@@ -4,5 +4,6 @@ Client: To Ellis
 - meetings/: Notes and agendas
 - strategy/: Planning docs
 - design/: Design assets
-- website/: Website work
- - deliverables/: archived under `../../archive/to-ellis/deliverables`
+- deliverables/: archived under `../../archive/to-ellis/deliverables`
+
+Website work lives in `themes/to-ellis/website/`.

--- a/clients/vbm-elektro/README.md
+++ b/clients/vbm-elektro/README.md
@@ -6,6 +6,7 @@ Client folder for VBM Elektro.
 - **meetings/** – Notes and agendas from meetings
 - **strategy/** – Project strategy, goals, and plans
 - **design/** – Design files, logo assets, and graphics
-- **website/** – Any web or digital deliverables
- - **deliverables/** – archived under `../../archive/vbm-elektro/deliverables`
+- **deliverables/** – archived under `../../archive/vbm-elektro/deliverables`
+
+Any website deliverables are kept in `themes/vbm-elektro/website/`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,12 +5,13 @@ This document explains the overall structure of the Nesheim & Vatten repository 
 ## Folder overview
 
 - `archive/` – archived or outdated resources kept for reference
-- `clients/` – per-client project files (contracts, meetings, design, website, etc.)
+- `clients/` – per-client project files (contracts, meetings, design, etc.)
 - `docs/` – documentation, brand assets and marketing material
 - `styles/` – global design tokens and CSS used across projects
 - `templates/` – reusable templates such as proposals or invoices
 - `tests/` – automated Jest test suite
 - `tools/` – helper scripts like `create-structure.sh`
+- `themes/` – Shopify themes and static site code
 
 The `.github/` directory contains GitHub Actions workflows for linting and testing.
 
@@ -23,7 +24,6 @@ Client work is grouped under `clients/<client-name>/`. Each client folder normal
 - `strategy/`
 - `design/`
 - `deliverables/`
-- `website/`
 
 A website project lives inside `themes/<client-name>/website/<project-name>` or directly under `themes/` if there is only one site. You can run `./tools/create-structure.sh` to generate a basic directory tree.
 

--- a/docs/folder-structure.txt
+++ b/docs/folder-structure.txt
@@ -13,4 +13,4 @@ clients/comma/
 ├── sales-integrations/     # Channel-specific sales configurations
 ├── seo/                    # Keyword research and SEO templates
 ├── strategy/               # Roadmaps and high level planning documents
-└── website/                # Source code for comma-records.com
+# Website code lives in `themes/comma/website/`

--- a/docs/internal-guidelines.md
+++ b/docs/internal-guidelines.md
@@ -50,7 +50,8 @@ Each client gets their own structured folder under `clients/`, with these subfol
 - `design/`
 - `meetings/`
 - `strategy/`
-- `website/`
+
+Website code is stored under `themes/<client-name>/website/`.
 
 Refer to `folder-structure.txt` for the complete directory tree.
 


### PR DESCRIPTION
## Summary
- replace old website path examples with new `themes` locations
- adjust client READMEs for updated theme directories
- document themes folder in `ARCHITECTURE.md`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a97db92d08328bc16ab7328deecaf