### PR TITLE
Add DOM interaction tests

### DIFF
--- a/tests/main-search.test.js
+++ b/tests/main-search.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('MainSearch keepInSync and focus behavior', () => {
+  let window, document, MainSearch, instance;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><form id="f1"><main-search><input type="search"><button type="reset" class="hidden"></button></main-search></form><form id="f2"><input type="search"></form>`);
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+    global.HTMLElement = window.HTMLElement;
+    global.customElements = window.customElements;
+    global.debounce = (fn) => fn;
+
+    global.SearchForm = require(path.resolve(__dirname, '../themes/website-v1/assets/search-form.js'));
+
+    const scriptPath = path.resolve(__dirname, '../themes/website-v1/assets/main-search.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.Function(scriptContent).call(window);
+    MainSearch = window.customElements.get('main-search');
+
+    instance = document.createElement('main-search');
+    Object.setPrototypeOf(instance, MainSearch.prototype);
+    instance.innerHTML = '<input type="search"><button type="reset" class="hidden"></button>';
+    document.getElementById('f1').replaceChild(instance, document.querySelector('main-search'));
+    instance.input = instance.querySelector('input[type="search"]');
+    instance.allSearchInputs = document.querySelectorAll('input[type="search"]');
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.customElements;
+    delete global.debounce;
+    delete global.SearchForm;
+  });
+
+  test('keepInSync updates other search inputs', () => {
+    const other = document.querySelector('#f2 input');
+    instance.keepInSync('abc', instance.input);
+    expect(other.value).toBe('abc');
+  });
+
+  test('onInputFocus scrolls into view on small screens', () => {
+    window.innerWidth = 400;
+    const spy = jest.fn();
+    instance.scrollIntoView = spy;
+    instance.onInputFocus();
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/price-range.test.js
+++ b/tests/price-range.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('PriceRange component', () => {
+  let window, document, PriceRange, instance, minInput;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><price-range><input data-min="0" data-max="10" value="15"><input data-min="0" data-max="10" value="8"></price-range>`);
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+    global.HTMLElement = window.HTMLElement;
+    global.customElements = window.customElements;
+
+    const scriptPath = path.resolve(__dirname, '../themes/website-v1/assets/facets.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.Function(scriptContent).call(window);
+    PriceRange = window.customElements.get('price-range');
+    instance = document.querySelector('price-range');
+    Object.setPrototypeOf(instance, PriceRange.prototype);
+    minInput = instance.querySelector('input');
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.customElements;
+  });
+
+  test('adjustToValidValues limits input to max', () => {
+    instance.adjustToValidValues(minInput);
+    expect(minInput.value).toBe('8');
+  });
+
+  test('onKeyDown prevents invalid keys', () => {
+    const evt = { metaKey: false, key: 'a', preventDefault: jest.fn() };
+    instance.onKeyDown(evt);
+    expect(evt.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/tests/quick-order-list.test.js
+++ b/tests/quick-order-list.test.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('QuickOrderList updateMessage', () => {
+  let window, document, QuickOrderList, instance;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><quick-order-list></quick-order-list>`);
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+    global.HTMLElement = window.HTMLElement;
+    global.customElements = window.customElements;
+    global.BulkAdd = class extends window.HTMLElement {};
+    global.debounce = (fn) => fn;
+    global.publish = jest.fn();
+    global.PUB_SUB_EVENTS = { cartUpdate: 'cart-update' };
+    window.quickOrderListStrings = {
+      itemRemoved: 'Removed [quantity] item',
+      itemsRemoved: 'Removed [quantity] items',
+      itemAdded: 'Added [quantity] item',
+      itemsAdded: 'Added [quantity] items'
+    };
+
+    const scriptPath = path.resolve(__dirname, '../themes/website-v1/assets/quick-order-list.js');
+    const scriptContent = fs.readFileSync(scriptPath, 'utf8');
+    window.Function(scriptContent).call(window);
+    QuickOrderList = window.customElements.get('quick-order-list');
+
+    instance = document.createElement('quick-order-list');
+    Object.setPrototypeOf(instance, QuickOrderList.prototype);
+    instance.innerHTML = '<form></form><div class="quick-order-list__total"></div><div class="quick-order-list__table"></div><span class="quick-order-list__message-text"></span><span class="quick-order-list__message-icon hidden"></span>';
+    document.body.appendChild(instance);
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.customElements;
+    delete global.BulkAdd;
+    delete global.debounce;
+    delete global.publish;
+    delete global.PUB_SUB_EVENTS;
+  });
+
+  test('shows icon when quantity positive', () => {
+    const icon = instance.querySelector('.quick-order-list__message-icon');
+    instance.updateMessage(2);
+    expect(icon.classList.contains('hidden')).toBe(false);
+    expect(instance.querySelector('.quick-order-list__message-text').innerHTML).toBe('Added 2 items');
+  });
+
+  test('hides icon when quantity negative', () => {
+    const icon = instance.querySelector('.quick-order-list__message-icon');
+    instance.updateMessage(-1);
+    expect(icon.classList.contains('hidden')).toBe(true);
+    expect(instance.querySelector('.quick-order-list__message-text').innerHTML).toBe('Removed 1 item');
+  });
+});


### PR DESCRIPTION
## Summary
- add jest tests for `main-search` custom element
- cover `PriceRange` functionality with JSDOM
- test `quick-order-list` messaging logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aaa25df6083288f5fc2a46d9770d7