### PR TITLE
Sanitize innerHTML usage

### DIFF
--- a/archive/clients/baattilsyn/website_v4/assets/cart.js
+++ b/archive/clients/baattilsyn/website_v4/assets/cart.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 class CartRemoveButton extends HTMLElement {
   constructor() {
     super();
@@ -131,7 +134,7 @@ class CartItems extends HTMLElement {
             'text/html'
           );
           const sourceQty = html.querySelector('cart-items');
-          this.innerHTML = sourceQty.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
         })
         .catch((e) => {
           console.error(e);
@@ -312,9 +315,11 @@ class CartItems extends HTMLElement {
   }
 
   getSectionInnerHTML(html, selector) {
-    return new DOMParser()
-      .parseFromString(html, 'text/html')
-      .querySelector(selector).innerHTML;
+    return DOMPurify.sanitize(
+      new DOMParser()
+        .parseFromString(html, 'text/html')
+        .querySelector(selector).innerHTML
+    );
   }
 
   enableLoading(line) {

--- a/archive/clients/baattilsyn/website_v4/assets/global.js
+++ b/archive/clients/baattilsyn/website_v4/assets/global.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 function getFocusableElements(container) {
   return Array.from(
     container.querySelectorAll(
@@ -65,7 +68,7 @@ class HTMLUpdateUtility {
 
   // Sets inner HTML and reinjects the script tags to allow execution. By default, scripts are disabled when using element.innerHTML.
   static setInnerHTML(element, html) {
-    element.innerHTML = html;
+    element.innerHTML = DOMPurify.sanitize(html);
     element.querySelectorAll('script').forEach((oldScriptTag) => {
       const newScriptTag = document.createElement('script');
       Array.from(oldScriptTag.attributes).forEach((attribute) => {
@@ -447,7 +450,7 @@ Shopify.CountryProvinceSelector.prototype = {
       for (var i = 0; i < provinces.length; i++) {
         var opt = document.createElement('option');
         opt.value = provinces[i][0];
-        opt.innerHTML = provinces[i][1];
+        opt.textContent = provinces[i][1];
         this.provinceEl.appendChild(opt);
       }
 
@@ -465,7 +468,7 @@ Shopify.CountryProvinceSelector.prototype = {
     for (var i = 0, count = values.length; i < values.length; i++) {
       var opt = document.createElement('option');
       opt.value = values[i];
-      opt.innerHTML = values[i];
+      opt.textContent = values[i];
       selector.appendChild(opt);
     }
   },
@@ -767,7 +770,7 @@ class BulkModal extends HTMLElement {
             const sourceQty = html.querySelector(
               '.quick-order-list-container'
             ).parentNode;
-            this.innerHTML = sourceQty.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
           })
           .catch((e) => {
             console.error(e);

--- a/archive/clients/nome-ror-as/nome-ror-as-website-v3/assets/cart.js
+++ b/archive/clients/nome-ror-as/nome-ror-as-website-v3/assets/cart.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 class CartRemoveButton extends HTMLElement {
   constructor() {
     super();
@@ -111,7 +114,7 @@ class CartItems extends HTMLElement {
         .then((responseText) => {
           const html = new DOMParser().parseFromString(responseText, 'text/html');
           const sourceQty = html.querySelector('cart-items');
-          this.innerHTML = sourceQty.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
         })
         .catch((e) => {
           console.error(e);
@@ -243,7 +246,9 @@ class CartItems extends HTMLElement {
   }
 
   getSectionInnerHTML(html, selector) {
-    return new DOMParser().parseFromString(html, 'text/html').querySelector(selector).innerHTML;
+    return DOMPurify.sanitize(
+      new DOMParser().parseFromString(html, 'text/html').querySelector(selector).innerHTML
+    );
   }
 
   enableLoading(line) {

--- a/tests/cart.test.js
+++ b/tests/cart.test.js
@@ -16,9 +16,12 @@ describe('CartItems.getSectionInnerHTML', () => {
     global.debounce = (fn) => fn;
     global.ON_CHANGE_DEBOUNCE_TIMER = 0;
     global.trapFocus = jest.fn();
-    global.fetchConfig = () => ({})
+    global.fetchConfig = () => ({});
     global.routes = { cart_change_url: '', cart_update_url: '', cart_url: '' };
-    global.CartPerformance = { measure: jest.fn((_, fn) => fn()), measureFromEvent: jest.fn() };
+    global.CartPerformance = {
+      measure: jest.fn((_, fn) => fn()),
+      measureFromEvent: jest.fn(),
+    };
     global.publish = jest.fn();
     global.PUB_SUB_EVENTS = { cartUpdate: 'cart-update' };
 
@@ -54,7 +57,13 @@ describe('CartItems.getSectionInnerHTML', () => {
   });
 
   test('strips script tags from HTML', () => {
-    const html = '<div><span class="target">hi<script>alert(1)</script></span></div>';
+    const html =
+      '<div><span class="target">hi<script>alert(1)</script></span></div>';
+    expect(instance.getSectionInnerHTML(html, '.target')).toBe('hi');
+  });
+
+  test('removes inline event handlers', () => {
+    const html = '<div><span class="target" onclick="alert(1)">hi</span></div>';
     expect(instance.getSectionInnerHTML(html, '.target')).toBe('hi');
   });
 });

--- a/themes/website-v2/assets/cart.js
+++ b/themes/website-v2/assets/cart.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 class CartRemoveButton extends HTMLElement {
   constructor() {
     super();
@@ -131,7 +134,7 @@ class CartItems extends HTMLElement {
             'text/html'
           );
           const sourceQty = html.querySelector('cart-items');
-          this.innerHTML = sourceQty.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
         })
         .catch((e) => {
           console.error(e);
@@ -309,9 +312,10 @@ class CartItems extends HTMLElement {
   }
 
   getSectionInnerHTML(html, selector) {
-    return new DOMParser()
-      .parseFromString(html, 'text/html')
-      .querySelector(selector).innerHTML;
+    return DOMPurify.sanitize(
+      new DOMParser().parseFromString(html, 'text/html').querySelector(selector)
+        .innerHTML
+    );
   }
 
   enableLoading(line) {

--- a/themes/website-v2/assets/global.js
+++ b/themes/website-v2/assets/global.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 function getFocusableElements(container) {
   return Array.from(
     container.querySelectorAll(
@@ -32,7 +35,12 @@ class HTMLUpdateUtility {
    *
    * The function currently uses a double buffer approach, but this should be replaced by a view transition once it is more widely supported https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API
    */
-  static viewTransition(oldNode, newContent, preProcessCallbacks = [], postProcessCallbacks = []) {
+  static viewTransition(
+    oldNode,
+    newContent,
+    preProcessCallbacks = [],
+    postProcessCallbacks = []
+  ) {
     preProcessCallbacks?.forEach((callback) => callback(newContent));
 
     const newNodeWrapper = document.createElement('div');
@@ -43,7 +51,11 @@ class HTMLUpdateUtility {
     const uniqueKey = Date.now();
     oldNode.querySelectorAll('[id], [form]').forEach((element) => {
       element.id && (element.id = `${element.id}-${uniqueKey}`);
-      element.form && element.setAttribute('form', `${element.form.getAttribute('id')}-${uniqueKey}`);
+      element.form &&
+        element.setAttribute(
+          'form',
+          `${element.form.getAttribute('id')}-${uniqueKey}`
+        );
     });
 
     oldNode.parentNode.insertBefore(newNode, oldNode);
@@ -56,7 +68,7 @@ class HTMLUpdateUtility {
 
   // Sets inner HTML and reinjects the script tags to allow execution. By default, scripts are disabled when using element.innerHTML.
   static setInnerHTML(element, html) {
-    element.innerHTML = html;
+    element.innerHTML = DOMPurify.sanitize(html);
     element.querySelectorAll('script').forEach((oldScriptTag) => {
       const newScriptTag = document.createElement('script');
       Array.from(oldScriptTag.attributes).forEach((attribute) => {
@@ -70,14 +82,20 @@ class HTMLUpdateUtility {
 
 document.querySelectorAll('[id^="Details-"] summary').forEach((summary) => {
   summary.setAttribute('role', 'button');
-  summary.setAttribute('aria-expanded', summary.parentNode.hasAttribute('open'));
+  summary.setAttribute(
+    'aria-expanded',
+    summary.parentNode.hasAttribute('open')
+  );
 
   if (summary.nextElementSibling.getAttribute('id')) {
     summary.setAttribute('aria-controls', summary.nextElementSibling.id);
   }
 
   summary.addEventListener('click', (event) => {
-    event.currentTarget.setAttribute('aria-expanded', !event.currentTarget.closest('details').hasAttribute('open'));
+    event.currentTarget.setAttribute(
+      'aria-expanded',
+      !event.currentTarget.closest('details').hasAttribute('open')
+    );
   });
 
   if (summary.closest('header-drawer, menu-drawer')) return;
@@ -94,7 +112,12 @@ function trapFocus(container, elementToFocus = container) {
   removeTrapFocus();
 
   trapFocusHandlers.focusin = (event) => {
-    if (event.target !== container && event.target !== last && event.target !== first) return;
+    if (
+      event.target !== container &&
+      event.target !== last &&
+      event.target !== first
+    )
+      return;
 
     document.addEventListener('keydown', trapFocusHandlers.keydown);
   };
@@ -112,7 +135,10 @@ function trapFocus(container, elementToFocus = container) {
     }
 
     //  On the first focusable element and tab backward, focus the last element.
-    if ((event.target === container || event.target === first) && event.shiftKey) {
+    if (
+      (event.target === container || event.target === first) &&
+      event.shiftKey
+    ) {
       event.preventDefault();
       last.focus();
     }
@@ -170,7 +196,8 @@ function focusVisiblePolyfill() {
   window.addEventListener(
     'focus',
     () => {
-      if (currentFocusedElement) currentFocusedElement.classList.remove('focused');
+      if (currentFocusedElement)
+        currentFocusedElement.classList.remove('focused');
 
       if (mouseClick) return;
 
@@ -183,7 +210,10 @@ function focusVisiblePolyfill() {
 
 function pauseAllMedia() {
   document.querySelectorAll('.js-youtube').forEach((video) => {
-    video.contentWindow.postMessage('{"event":"command","func":"' + 'pauseVideo' + '","args":""}', '*');
+    video.contentWindow.postMessage(
+      '{"event":"command","func":"' + 'pauseVideo' + '","args":""}',
+      '*'
+    );
   });
   document.querySelectorAll('.js-vimeo').forEach((video) => {
     video.contentWindow.postMessage('{"method":"pause"}', '*');
@@ -229,7 +259,10 @@ class QuantityInput extends HTMLElement {
 
   connectedCallback() {
     this.validateQtyRules();
-    this.quantityUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.quantityUpdate, this.validateQtyRules.bind(this));
+    this.quantityUpdateUnsubscriber = subscribe(
+      PUB_SUB_EVENTS.quantityUpdate,
+      this.validateQtyRules.bind(this)
+    );
   }
 
   disconnectedCallback() {
@@ -247,7 +280,10 @@ class QuantityInput extends HTMLElement {
     const previousValue = this.input.value;
 
     if (event.target.name === 'plus') {
-      if (parseInt(this.input.dataset.min) > parseInt(this.input.step) && this.input.value == 0) {
+      if (
+        parseInt(this.input.dataset.min) > parseInt(this.input.step) &&
+        this.input.value == 0
+      ) {
         this.input.value = this.input.dataset.min;
       } else {
         this.input.stepUp();
@@ -256,9 +292,13 @@ class QuantityInput extends HTMLElement {
       this.input.stepDown();
     }
 
-    if (previousValue !== this.input.value) this.input.dispatchEvent(this.changeEvent);
+    if (previousValue !== this.input.value)
+      this.input.dispatchEvent(this.changeEvent);
 
-    if (this.input.dataset.min === previousValue && event.target.name === 'minus') {
+    if (
+      this.input.dataset.min === previousValue &&
+      event.target.name === 'minus'
+    ) {
       this.input.value = parseInt(this.input.min);
     }
   }
@@ -267,7 +307,10 @@ class QuantityInput extends HTMLElement {
     const value = parseInt(this.input.value);
     if (this.input.min) {
       const buttonMinus = this.querySelector(".quantity__button[name='minus']");
-      buttonMinus.classList.toggle('disabled', parseInt(value) <= parseInt(this.input.min));
+      buttonMinus.classList.toggle(
+        'disabled',
+        parseInt(value) <= parseInt(this.input.min)
+      );
     }
     if (this.input.max) {
       const max = parseInt(this.input.max);
@@ -287,7 +330,6 @@ function debounce(fn, wait) {
   };
 }
 
-
 function throttle(fn, delay) {
   let lastCall = 0;
   return function (...args) {
@@ -303,7 +345,10 @@ function throttle(fn, delay) {
 function fetchConfig(type = 'json') {
   return {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Accept: `application/${type}` },
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: `application/${type}`,
+    },
   };
 }
 
@@ -358,12 +403,22 @@ Shopify.postLink = function (path, options) {
   document.body.removeChild(form);
 };
 
-Shopify.CountryProvinceSelector = function (country_domid, province_domid, options) {
+Shopify.CountryProvinceSelector = function (
+  country_domid,
+  province_domid,
+  options
+) {
   this.countryEl = document.getElementById(country_domid);
   this.provinceEl = document.getElementById(province_domid);
-  this.provinceContainer = document.getElementById(options['hideElement'] || province_domid);
+  this.provinceContainer = document.getElementById(
+    options['hideElement'] || province_domid
+  );
 
-  Shopify.addListener(this.countryEl, 'change', Shopify.bind(this.countryHandler, this));
+  Shopify.addListener(
+    this.countryEl,
+    'change',
+    Shopify.bind(this.countryHandler, this)
+  );
 
   this.initCountry();
   this.initProvince();
@@ -395,7 +450,7 @@ Shopify.CountryProvinceSelector.prototype = {
       for (var i = 0; i < provinces.length; i++) {
         var opt = document.createElement('option');
         opt.value = provinces[i][0];
-        opt.innerHTML = provinces[i][1];
+        opt.textContent = provinces[i][1];
         this.provinceEl.appendChild(opt);
       }
 
@@ -413,7 +468,7 @@ Shopify.CountryProvinceSelector.prototype = {
     for (var i = 0, count = values.length; i < values.length; i++) {
       var opt = document.createElement('option');
       opt.value = values[i];
-      opt.innerHTML = values[i];
+      opt.textContent = values[i];
       selector.appendChild(opt);
     }
   },
@@ -436,7 +491,9 @@ class MenuDrawer extends HTMLElement {
     );
     this.querySelectorAll(
       'button:not(.localization-selector):not(.country-selector__close-button):not(.country-filter__reset-button)'
-    ).forEach((button) => button.addEventListener('click', this.onCloseButtonClick.bind(this)));
+    ).forEach((button) =>
+      button.addEventListener('click', this.onCloseButtonClick.bind(this))
+    );
   }
 
   onKeyUp(event) {
@@ -446,7 +503,10 @@ class MenuDrawer extends HTMLElement {
     if (!openDetailsElement) return;
 
     openDetailsElement === this.mainDetailsToggle
-      ? this.closeMenuDrawer(event, this.mainDetailsToggle.querySelector('summary'))
+      ? this.closeMenuDrawer(
+          event,
+          this.mainDetailsToggle.querySelector('summary')
+        )
       : this.closeSubmenu(openDetailsElement);
   }
 
@@ -458,16 +518,27 @@ class MenuDrawer extends HTMLElement {
     const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
     function addTrapFocus() {
-      trapFocus(summaryElement.nextElementSibling, detailsElement.querySelector('button'));
-      summaryElement.nextElementSibling.removeEventListener('transitionend', addTrapFocus);
+      trapFocus(
+        summaryElement.nextElementSibling,
+        detailsElement.querySelector('button')
+      );
+      summaryElement.nextElementSibling.removeEventListener(
+        'transitionend',
+        addTrapFocus
+      );
     }
 
     if (detailsElement === this.mainDetailsToggle) {
       if (isOpen) event.preventDefault();
-      isOpen ? this.closeMenuDrawer(event, summaryElement) : this.openMenuDrawer(summaryElement);
+      isOpen
+        ? this.closeMenuDrawer(event, summaryElement)
+        : this.openMenuDrawer(summaryElement);
 
       if (window.matchMedia('(max-width: 990px)')) {
-        document.documentElement.style.setProperty('--viewport-height', `${window.innerHeight}px`);
+        document.documentElement.style.setProperty(
+          '--viewport-height',
+          `${window.innerHeight}px`
+        );
       }
     } else {
       setTimeout(() => {
@@ -476,7 +547,10 @@ class MenuDrawer extends HTMLElement {
         parentMenuElement && parentMenuElement.classList.add('submenu-open');
         !reducedMotion || reducedMotion.matches
           ? addTrapFocus()
-          : summaryElement.nextElementSibling.addEventListener('transitionend', addTrapFocus);
+          : summaryElement.nextElementSibling.addEventListener(
+              'transitionend',
+              addTrapFocus
+            );
       }, 100);
     }
   }
@@ -498,19 +572,27 @@ class MenuDrawer extends HTMLElement {
       details.removeAttribute('open');
       details.classList.remove('menu-opening');
     });
-    this.mainDetailsToggle.querySelectorAll('.submenu-open').forEach((submenu) => {
-      submenu.classList.remove('submenu-open');
-    });
-    document.body.classList.remove(`overflow-hidden-${this.dataset.breakpoint}`);
+    this.mainDetailsToggle
+      .querySelectorAll('.submenu-open')
+      .forEach((submenu) => {
+        submenu.classList.remove('submenu-open');
+      });
+    document.body.classList.remove(
+      `overflow-hidden-${this.dataset.breakpoint}`
+    );
     removeTrapFocus(elementToFocus);
     this.closeAnimation(this.mainDetailsToggle);
 
-    if (event instanceof KeyboardEvent) elementToFocus?.setAttribute('aria-expanded', false);
+    if (event instanceof KeyboardEvent)
+      elementToFocus?.setAttribute('aria-expanded', false);
   }
 
   onFocusOut() {
     setTimeout(() => {
-      if (this.mainDetailsToggle.hasAttribute('open') && !this.mainDetailsToggle.contains(document.activeElement))
+      if (
+        this.mainDetailsToggle.hasAttribute('open') &&
+        !this.mainDetailsToggle.contains(document.activeElement)
+      )
         this.closeMenuDrawer();
     });
   }
@@ -524,7 +606,9 @@ class MenuDrawer extends HTMLElement {
     const parentMenuElement = detailsElement.closest('.submenu-open');
     parentMenuElement && parentMenuElement.classList.remove('submenu-open');
     detailsElement.classList.remove('menu-opening');
-    detailsElement.querySelector('summary').setAttribute('aria-expanded', false);
+    detailsElement
+      .querySelector('summary')
+      .setAttribute('aria-expanded', false);
     removeTrapFocus(detailsElement.querySelector('summary'));
     this.closeAnimation(detailsElement);
   }
@@ -544,7 +628,10 @@ class MenuDrawer extends HTMLElement {
       } else {
         detailsElement.removeAttribute('open');
         if (detailsElement.closest('details[open]')) {
-          trapFocus(detailsElement.closest('details[open]'), detailsElement.querySelector('summary'));
+          trapFocus(
+            detailsElement.closest('details[open]'),
+            detailsElement.querySelector('summary')
+          );
         }
       }
     };
@@ -563,7 +650,12 @@ class HeaderDrawer extends MenuDrawer {
   openMenuDrawer(summaryElement) {
     this.header = this.header || document.querySelector('.section-header');
     this.borderOffset =
-      this.borderOffset || this.closest('.header-wrapper').classList.contains('header-wrapper--border-bottom') ? 1 : 0;
+      this.borderOffset ||
+      this.closest('.header-wrapper').classList.contains(
+        'header-wrapper--border-bottom'
+      )
+        ? 1
+        : 0;
     document.documentElement.style.setProperty(
       '--header-bottom-position',
       `${parseInt(this.header.getBoundingClientRect().bottom - this.borderOffset)}px`
@@ -593,7 +685,10 @@ class HeaderDrawer extends MenuDrawer {
         '--header-bottom-position',
         `${parseInt(this.header.getBoundingClientRect().bottom - this.borderOffset)}px`
       );
-    document.documentElement.style.setProperty('--viewport-height', `${window.innerHeight}px`);
+    document.documentElement.style.setProperty(
+      '--viewport-height',
+      `${window.innerHeight}px`
+    );
   };
 }
 
@@ -602,13 +697,20 @@ customElements.define('header-drawer', HeaderDrawer);
 class ModalDialog extends HTMLElement {
   constructor() {
     super();
-    this.querySelector('[id^="ModalClose-"]').addEventListener('click', this.hide.bind(this, false));
+    this.querySelector('[id^="ModalClose-"]').addEventListener(
+      'click',
+      this.hide.bind(this, false)
+    );
     this.addEventListener('keyup', (event) => {
       if (event.code.toUpperCase() === 'ESCAPE') this.hide();
     });
     if (this.classList.contains('media-modal')) {
       this.addEventListener('pointerup', (event) => {
-        if (event.pointerType === 'mouse' && !event.target.closest('deferred-media, product-model')) this.hide();
+        if (
+          event.pointerType === 'mouse' &&
+          !event.target.closest('deferred-media, product-model')
+        )
+          this.hide();
       });
     } else {
       this.addEventListener('click', (event) => {
@@ -620,7 +722,10 @@ class ModalDialog extends HTMLElement {
   connectedCallback() {
     if (this.moved) return;
     this.moved = true;
-    this.dataset.section = this.closest('.shopify-section').id.replace('shopify-section-', '');
+    this.dataset.section = this.closest('.shopify-section').id.replace(
+      'shopify-section-',
+      ''
+    );
     document.body.appendChild(this);
   }
 
@@ -658,9 +763,14 @@ class BulkModal extends HTMLElement {
         fetch(`${productUrl}?section_id=bulk-quick-order-list`)
           .then((response) => response.text())
           .then((responseText) => {
-            const html = new DOMParser().parseFromString(responseText, 'text/html');
-            const sourceQty = html.querySelector('.quick-order-list-container').parentNode;
-            this.innerHTML = sourceQty.innerHTML;
+            const html = new DOMParser().parseFromString(
+              responseText,
+              'text/html'
+            );
+            const sourceQty = html.querySelector(
+              '.quick-order-list-container'
+            ).parentNode;
+            this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
           })
           .catch((e) => {
             console.error(e);
@@ -669,7 +779,9 @@ class BulkModal extends HTMLElement {
     };
 
     new IntersectionObserver(handleIntersection.bind(this)).observe(
-      document.querySelector(`#QuickBulk-${this.dataset.productId}-${this.dataset.sectionId}`)
+      document.querySelector(
+        `#QuickBulk-${this.dataset.productId}-${this.dataset.sectionId}`
+      )
     );
   }
 }
@@ -703,12 +815,19 @@ class DeferredMedia extends HTMLElement {
     window.pauseAllMedia();
     if (!this.getAttribute('loaded')) {
       const content = document.createElement('div');
-      content.appendChild(this.querySelector('template').content.firstElementChild.cloneNode(true));
+      content.appendChild(
+        this.querySelector('template').content.firstElementChild.cloneNode(true)
+      );
 
       this.setAttribute('loaded', true);
-      const deferredElement = this.appendChild(content.querySelector('video, model-viewer, iframe'));
+      const deferredElement = this.appendChild(
+        content.querySelector('video, model-viewer, iframe')
+      );
       if (focus) deferredElement.focus();
-      if (deferredElement.nodeName == 'VIDEO' && deferredElement.getAttribute('autoplay')) {
+      if (
+        deferredElement.nodeName == 'VIDEO' &&
+        deferredElement.getAttribute('autoplay')
+      ) {
         // force autoplay for safari
         deferredElement.play();
       }
@@ -748,11 +867,16 @@ class SliderComponent extends HTMLElement {
   }
 
   initPages() {
-    this.sliderItemsToShow = Array.from(this.sliderItems).filter((element) => element.clientWidth > 0);
+    this.sliderItemsToShow = Array.from(this.sliderItems).filter(
+      (element) => element.clientWidth > 0
+    );
     if (this.sliderItemsToShow.length < 2) return;
-    this.sliderItemOffset = this.sliderItemsToShow[1].offsetLeft - this.sliderItemsToShow[0].offsetLeft;
+    this.sliderItemOffset =
+      this.sliderItemsToShow[1].offsetLeft -
+      this.sliderItemsToShow[0].offsetLeft;
     this.slidesPerPage = Math.floor(
-      (this.slider.clientWidth - this.sliderItemsToShow[0].offsetLeft) / this.sliderItemOffset
+      (this.slider.clientWidth - this.sliderItemsToShow[0].offsetLeft) /
+        this.sliderItemOffset
     );
     this.totalPages = this.sliderItemsToShow.length - this.slidesPerPage + 1;
     this.update();
@@ -769,7 +893,8 @@ class SliderComponent extends HTMLElement {
     if (!this.slider || !this.nextButton) return;
 
     const previousPage = this.currentPage;
-    this.currentPage = Math.round(this.slider.scrollLeft / this.sliderItemOffset) + 1;
+    this.currentPage =
+      Math.round(this.slider.scrollLeft / this.sliderItemOffset) + 1;
 
     if (this.currentPageElement && this.pageTotalElement) {
       this.currentPageElement.textContent = this.currentPage;
@@ -789,13 +914,20 @@ class SliderComponent extends HTMLElement {
 
     if (this.enableSliderLooping) return;
 
-    if (this.isSlideVisible(this.sliderItemsToShow[0]) && this.slider.scrollLeft === 0) {
+    if (
+      this.isSlideVisible(this.sliderItemsToShow[0]) &&
+      this.slider.scrollLeft === 0
+    ) {
       this.prevButton.setAttribute('disabled', 'disabled');
     } else {
       this.prevButton.removeAttribute('disabled');
     }
 
-    if (this.isSlideVisible(this.sliderItemsToShow[this.sliderItemsToShow.length - 1])) {
+    if (
+      this.isSlideVisible(
+        this.sliderItemsToShow[this.sliderItemsToShow.length - 1]
+      )
+    ) {
       this.nextButton.setAttribute('disabled', 'disabled');
     } else {
       this.nextButton.removeAttribute('disabled');
@@ -803,8 +935,12 @@ class SliderComponent extends HTMLElement {
   }
 
   isSlideVisible(element, offset = 0) {
-    const lastVisibleSlide = this.slider.clientWidth + this.slider.scrollLeft - offset;
-    return element.offsetLeft + element.clientWidth <= lastVisibleSlide && element.offsetLeft >= this.slider.scrollLeft;
+    const lastVisibleSlide =
+      this.slider.clientWidth + this.slider.scrollLeft - offset;
+    return (
+      element.offsetLeft + element.clientWidth <= lastVisibleSlide &&
+      element.offsetLeft >= this.slider.scrollLeft
+    );
   }
 
   onButtonClick(event) {
@@ -841,17 +977,24 @@ class SlideshowComponent extends SliderComponent {
     // Value below should match --duration-announcement-bar CSS value
     this.announcerBarAnimationDelay = this.announcementBarSlider ? 250 : 0;
 
-    this.sliderControlLinksArray = Array.from(this.sliderControlWrapper.querySelectorAll('.slider-counter__link'));
-    this.sliderControlLinksArray.forEach((link) => link.addEventListener('click', this.linkToSlide.bind(this)));
+    this.sliderControlLinksArray = Array.from(
+      this.sliderControlWrapper.querySelectorAll('.slider-counter__link')
+    );
+    this.sliderControlLinksArray.forEach((link) =>
+      link.addEventListener('click', this.linkToSlide.bind(this))
+    );
     this.slider.addEventListener('scroll', this.setSlideVisibility.bind(this));
     this.setSlideVisibility();
 
     if (this.announcementBarSlider) {
       this.announcementBarArrowButtonWasClicked = false;
 
-      this.reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+      this.reducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      );
       this.reducedMotion.addEventListener('change', () => {
-        if (this.slider.getAttribute('data-autoplay') === 'true') this.setAutoPlay();
+        if (this.slider.getAttribute('data-autoplay') === 'true')
+          this.setAutoPlay();
       });
 
       [this.prevButton, this.nextButton].forEach((button) => {
@@ -865,7 +1008,8 @@ class SlideshowComponent extends SliderComponent {
       });
     }
 
-    if (this.slider.getAttribute('data-autoplay') === 'true') this.setAutoPlay();
+    if (this.slider.getAttribute('data-autoplay') === 'true')
+      this.setAutoPlay();
   }
 
   setAutoPlay() {
@@ -877,11 +1021,16 @@ class SlideshowComponent extends SliderComponent {
 
     if (this.querySelector('.slideshow__autoplay')) {
       this.sliderAutoplayButton = this.querySelector('.slideshow__autoplay');
-      this.sliderAutoplayButton.addEventListener('click', this.autoPlayToggle.bind(this));
+      this.sliderAutoplayButton.addEventListener(
+        'click',
+        this.autoPlayToggle.bind(this)
+      );
       this.autoplayButtonIsSetToPlay = true;
       this.play();
     } else {
-      this.reducedMotion.matches || this.announcementBarArrowButtonWasClicked ? this.pause() : this.play();
+      this.reducedMotion.matches || this.announcementBarArrowButtonWasClicked
+        ? this.pause()
+        : this.play();
     }
   }
 
@@ -899,7 +1048,8 @@ class SlideshowComponent extends SliderComponent {
 
     if (isFirstSlide && event.currentTarget.name === 'previous') {
       this.slideScrollPosition =
-        this.slider.scrollLeft + this.sliderFirstItemNode.clientWidth * this.sliderItemsToShow.length;
+        this.slider.scrollLeft +
+        this.sliderFirstItemNode.clientWidth * this.sliderItemsToShow.length;
     } else if (isLastSlide && event.currentTarget.name === 'next') {
       this.slideScrollPosition = 0;
     }
@@ -929,8 +1079,13 @@ class SlideshowComponent extends SliderComponent {
       link.classList.remove('slider-counter__link--active');
       link.removeAttribute('aria-current');
     });
-    this.sliderControlButtons[this.currentPage - 1].classList.add('slider-counter__link--active');
-    this.sliderControlButtons[this.currentPage - 1].setAttribute('aria-current', true);
+    this.sliderControlButtons[this.currentPage - 1].classList.add(
+      'slider-counter__link--active'
+    );
+    this.sliderControlButtons[this.currentPage - 1].setAttribute(
+      'aria-current',
+      true
+    );
   }
 
   autoPlayToggle() {
@@ -942,10 +1097,14 @@ class SlideshowComponent extends SliderComponent {
   focusOutHandling(event) {
     if (this.sliderAutoplayButton) {
       const focusedOnAutoplayButton =
-        event.target === this.sliderAutoplayButton || this.sliderAutoplayButton.contains(event.target);
+        event.target === this.sliderAutoplayButton ||
+        this.sliderAutoplayButton.contains(event.target);
       if (!this.autoplayButtonIsSetToPlay || focusedOnAutoplayButton) return;
       this.play();
-    } else if (!this.reducedMotion.matches && !this.announcementBarArrowButtonWasClicked) {
+    } else if (
+      !this.reducedMotion.matches &&
+      !this.announcementBarArrowButtonWasClicked
+    ) {
       this.play();
     }
   }
@@ -953,7 +1112,8 @@ class SlideshowComponent extends SliderComponent {
   focusInHandling(event) {
     if (this.sliderAutoplayButton) {
       const focusedOnAutoplayButton =
-        event.target === this.sliderAutoplayButton || this.sliderAutoplayButton.contains(event.target);
+        event.target === this.sliderAutoplayButton ||
+        this.sliderAutoplayButton.contains(event.target);
       if (focusedOnAutoplayButton && this.autoplayButtonIsSetToPlay) {
         this.play();
       } else if (this.autoplayButtonIsSetToPlay) {
@@ -967,7 +1127,10 @@ class SlideshowComponent extends SliderComponent {
   play() {
     this.slider.setAttribute('aria-live', 'off');
     clearInterval(this.autoplay);
-    this.autoplay = setInterval(this.autoRotateSlides.bind(this), this.autoplaySpeed);
+    this.autoplay = setInterval(
+      this.autoRotateSlides.bind(this),
+      this.autoplaySpeed
+    );
   }
 
   pause() {
@@ -978,16 +1141,24 @@ class SlideshowComponent extends SliderComponent {
   togglePlayButtonState(pauseAutoplay) {
     if (pauseAutoplay) {
       this.sliderAutoplayButton.classList.add('slideshow__autoplay--paused');
-      this.sliderAutoplayButton.setAttribute('aria-label', window.accessibilityStrings.playSlideshow);
+      this.sliderAutoplayButton.setAttribute(
+        'aria-label',
+        window.accessibilityStrings.playSlideshow
+      );
     } else {
       this.sliderAutoplayButton.classList.remove('slideshow__autoplay--paused');
-      this.sliderAutoplayButton.setAttribute('aria-label', window.accessibilityStrings.pauseSlideshow);
+      this.sliderAutoplayButton.setAttribute(
+        'aria-label',
+        window.accessibilityStrings.pauseSlideshow
+      );
     }
   }
 
   autoRotateSlides() {
     const slideScrollPosition =
-      this.currentPage === this.sliderItems.length ? 0 : this.slider.scrollLeft + this.sliderItemOffset;
+      this.currentPage === this.sliderItems.length
+        ? 0
+        : this.slider.scrollLeft + this.sliderItemOffset;
 
     this.setSlidePosition(slideScrollPosition);
     this.applyAnimationToAnnouncementBar();
@@ -1034,7 +1205,9 @@ class SlideshowComponent extends SliderComponent {
     const isFirstSlide = currentIndex === 0;
     const isLastSlide = currentIndex === itemsCount - 1;
 
-    const shouldMoveNext = (button === 'next' && !isLastSlide) || (button === 'previous' && isFirstSlide);
+    const shouldMoveNext =
+      (button === 'next' && !isLastSlide) ||
+      (button === 'previous' && isFirstSlide);
     const direction = shouldMoveNext ? 'next' : 'previous';
 
     currentSlide.classList.add(`${animationClassOut}-${direction}`);
@@ -1051,7 +1224,9 @@ class SlideshowComponent extends SliderComponent {
     const slideScrollPosition =
       this.slider.scrollLeft +
       this.sliderFirstItemNode.clientWidth *
-        (this.sliderControlLinksArray.indexOf(event.currentTarget) + 1 - this.currentPage);
+        (this.sliderControlLinksArray.indexOf(event.currentTarget) +
+          1 -
+          this.currentPage);
     this.slider.scrollTo({
       left: slideScrollPosition,
     });
@@ -1095,10 +1270,16 @@ class VariantSelects extends HTMLElement {
         .querySelector('[data-selected-value] > .swatch');
       if (!selectedDropdownSwatchValue) return;
       if (swatchValue) {
-        selectedDropdownSwatchValue.style.setProperty('--swatch--background', swatchValue);
+        selectedDropdownSwatchValue.style.setProperty(
+          '--swatch--background',
+          swatchValue
+        );
         selectedDropdownSwatchValue.classList.remove('swatch--unavailable');
       } else {
-        selectedDropdownSwatchValue.style.setProperty('--swatch--background', 'unset');
+        selectedDropdownSwatchValue.style.setProperty(
+          '--swatch--background',
+          'unset'
+        );
         selectedDropdownSwatchValue.classList.add('swatch--unavailable');
       }
 
@@ -1107,8 +1288,10 @@ class VariantSelects extends HTMLElement {
         target.selectedOptions[0].dataset.optionSwatchFocalPoint || 'unset'
       );
     } else if (tagName === 'INPUT' && target.type === 'radio') {
-      const selectedSwatchValue = target.closest(`.product-form__input`).querySelector('[data-selected-value]');
-      if (selectedSwatchValue) selectedSwatchValue.innerHTML = value;
+      const selectedSwatchValue = target
+        .closest(`.product-form__input`)
+        .querySelector('[data-selected-value]');
+      if (selectedSwatchValue) selectedSwatchValue.textContent = value;
     }
   }
 
@@ -1117,9 +1300,9 @@ class VariantSelects extends HTMLElement {
   }
 
   get selectedOptionValues() {
-    return Array.from(this.querySelectorAll('select option[selected], fieldset input:checked')).map(
-      ({ dataset }) => dataset.optionValueId
-    );
+    return Array.from(
+      this.querySelectorAll('select option[selected], fieldset input:checked')
+    ).map(({ dataset }) => dataset.optionValueId);
   }
 }
 
@@ -1150,7 +1333,9 @@ class ProductRecommendations extends HTMLElement {
   }
 
   loadRecommendations(productId) {
-    fetch(`${this.dataset.url}&product_id=${productId}&section_id=${this.dataset.sectionId}`)
+    fetch(
+      `${this.dataset.url}&product_id=${productId}&section_id=${this.dataset.sectionId}`
+    )
       .then((response) => response.text())
       .then((text) => {
         const html = document.createElement('div');
@@ -1158,10 +1343,13 @@ class ProductRecommendations extends HTMLElement {
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
-          this.innerHTML = recommendations.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(recommendations.innerHTML);
         }
 
-        if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {
+        if (
+          !this.querySelector('slideshow-component') &&
+          this.classList.contains('complementary-products')
+        ) {
           this.remove();
         }
 
@@ -1185,7 +1373,10 @@ class AccountIcon extends HTMLElement {
   }
 
   connectedCallback() {
-    document.addEventListener('storefront:signincompleted', this.handleStorefrontSignInCompleted.bind(this));
+    document.addEventListener(
+      'storefront:signincompleted',
+      this.handleStorefrontSignInCompleted.bind(this)
+    );
   }
 
   handleStorefrontSignInCompleted(event) {
@@ -1228,7 +1419,9 @@ class BulkAdd extends HTMLElement {
     queue.forEach((queueItem) => {
       items[parseInt(queueItem.id)] = queueItem.quantity;
     });
-    this.queue = this.queue.filter((queueElement) => !queue.includes(queueElement));
+    this.queue = this.queue.filter(
+      (queueElement) => !queue.includes(queueElement)
+    );
 
     this.updateMultipleQty(items);
   }
@@ -1259,11 +1452,32 @@ class BulkAdd extends HTMLElement {
     const index = event.target.dataset.index;
 
     if (inputValue < event.target.dataset.min) {
-      this.setValidity(event, index, window.quickOrderListStrings.min_error.replace('[min]', event.target.dataset.min));
+      this.setValidity(
+        event,
+        index,
+        window.quickOrderListStrings.min_error.replace(
+          '[min]',
+          event.target.dataset.min
+        )
+      );
     } else if (inputValue > parseInt(event.target.max)) {
-      this.setValidity(event, index, window.quickOrderListStrings.max_error.replace('[max]', event.target.max));
+      this.setValidity(
+        event,
+        index,
+        window.quickOrderListStrings.max_error.replace(
+          '[max]',
+          event.target.max
+        )
+      );
     } else if (inputValue % parseInt(event.target.step) != 0) {
-      this.setValidity(event, index, window.quickOrderListStrings.step_error.replace('[step]', event.target.step));
+      this.setValidity(
+        event,
+        index,
+        window.quickOrderListStrings.step_error.replace(
+          '[step]',
+          event.target.step
+        )
+      );
     } else {
       event.target.setCustomValidity('');
       event.target.reportValidity();
@@ -1273,7 +1487,10 @@ class BulkAdd extends HTMLElement {
   }
 
   getSectionInnerHTML(html, selector) {
-    return new DOMParser().parseFromString(html, 'text/html').querySelector(selector).innerHTML;
+    return DOMPurify.sanitize(
+      new DOMParser().parseFromString(html, 'text/html').querySelector(selector)
+        .innerHTML
+    );
   }
 }
 
@@ -1282,17 +1499,17 @@ if (!customElements.get('bulk-add')) {
 }
 
 class CartPerformance {
-  static #metric_prefix = "cart-performance"
+  static #metric_prefix = 'cart-performance';
 
   static createStartingMarker(benchmarkName) {
-    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`
+    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`;
     return performance.mark(`${metricName}:start`);
   }
 
   static measureFromEvent(benchmarkName, event) {
-    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`
+    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`;
     const startMarker = performance.mark(`${metricName}:start`, {
-      startTime: event.timeStamp
+      startTime: event.timeStamp,
     });
 
     const endMarker = performance.mark(`${metricName}:end`);
@@ -1305,18 +1522,14 @@ class CartPerformance {
   }
 
   static measureFromMarker(benchmarkName, startMarker) {
-    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`
+    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`;
     const endMarker = performance.mark(`${metricName}:end`);
 
-    performance.measure(
-      benchmarkName,
-      startMarker.name,
-      `${metricName}:end`
-    );
+    performance.measure(benchmarkName, startMarker.name, `${metricName}:end`);
   }
 
   static measure(benchmarkName, callback) {
-    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`
+    const metricName = `${CartPerformance.#metric_prefix}:${benchmarkName}`;
     const startMarker = performance.mark(`${metricName}:start`);
 
     callback();

--- a/themes/website-v2/assets/quick-add-bulk.js
+++ b/themes/website-v2/assets/quick-add-bulk.js
@@ -1,3 +1,6 @@
+const createDOMPurify = require('dompurify');
+const DOMPurify = createDOMPurify(window);
+
 if (!customElements.get('quick-add-bulk')) {
   customElements.define(
     'quick-add-bulk',
@@ -8,7 +11,10 @@ if (!customElements.get('quick-add-bulk')) {
 
         const debouncedOnChange = debounce((event) => {
           if (parseInt(event.target.value) === 0) {
-            this.startQueue(event.target.dataset.index, parseInt(event.target.value));
+            this.startQueue(
+              event.target.dataset.index,
+              parseInt(event.target.value)
+            );
           } else {
             this.validateQuantity(event);
           }
@@ -21,20 +27,27 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       connectedCallback() {
-        this.cartUpdateUnsubscriber = subscribe(PUB_SUB_EVENTS.cartUpdate, (event) => {
-          if (
-            event.source === 'quick-add' ||
-            (event.cartData.items && !event.cartData.items.some((item) => item.id === parseInt(this.dataset.index))) ||
-            (event.cartData.variant_id && !(event.cartData.variant_id === parseInt(this.dataset.index)))
-          ) {
-            return;
+        this.cartUpdateUnsubscriber = subscribe(
+          PUB_SUB_EVENTS.cartUpdate,
+          (event) => {
+            if (
+              event.source === 'quick-add' ||
+              (event.cartData.items &&
+                !event.cartData.items.some(
+                  (item) => item.id === parseInt(this.dataset.index)
+                )) ||
+              (event.cartData.variant_id &&
+                !(event.cartData.variant_id === parseInt(this.dataset.index)))
+            ) {
+              return;
+            }
+            // If its another section that made the update
+            this.onCartUpdate().then(() => {
+              this.listenForActiveInput();
+              this.listenForKeydown();
+            });
           }
-          // If its another section that made the update
-          this.onCartUpdate().then(() => {
-            this.listenForActiveInput();
-            this.listenForKeydown();
-          });
-        });
+        );
       }
 
       disconnectedCallback() {
@@ -53,7 +66,9 @@ if (!customElements.get('quick-add-bulk')) {
 
       listenForActiveInput() {
         if (!this.classList.contains('hidden')) {
-          this.input?.addEventListener('focusin', (event) => event.target.select());
+          this.input?.addEventListener('focusin', (event) =>
+            event.target.select()
+          );
         }
         this.isEnterPressed = false;
       }
@@ -79,7 +94,9 @@ if (!customElements.get('quick-add-bulk')) {
 
       get sectionId() {
         if (!this._sectionId) {
-          this._sectionId = this.closest('.collection-quick-add-bulk').dataset.id;
+          this._sectionId = this.closest(
+            '.collection-quick-add-bulk'
+          ).dataset.id;
         }
 
         return this._sectionId;
@@ -90,10 +107,15 @@ if (!customElements.get('quick-add-bulk')) {
           fetch(`${this.getSectionsUrl()}?section_id=${this.sectionId}`)
             .then((response) => response.text())
             .then((responseText) => {
-              const html = new DOMParser().parseFromString(responseText, 'text/html');
-              const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
+              const html = new DOMParser().parseFromString(
+                responseText,
+                'text/html'
+              );
+              const sourceQty = html.querySelector(
+                `#quick-add-bulk-${this.dataset.index}-${this.sectionId}`
+              );
               if (sourceQty) {
-                this.innerHTML = sourceQty.innerHTML;
+                this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
               }
               resolve();
             })
@@ -117,7 +139,9 @@ if (!customElements.get('quick-add-bulk')) {
         const ids = Object.keys(items);
         const body = JSON.stringify({
           updates: items,
-          sections: this.getSectionsToRender().map((section) => section.section),
+          sections: this.getSectionsToRender().map(
+            (section) => section.section
+          ),
           sections_url: this.getSectionsUrl(),
         });
 
@@ -128,7 +152,10 @@ if (!customElements.get('quick-add-bulk')) {
           .then((state) => {
             const parsedState = JSON.parse(state);
             this.renderSections(parsedState, ids);
-            publish(PUB_SUB_EVENTS.cartUpdate, { source: 'quick-add', cartData: parsedState });
+            publish(PUB_SUB_EVENTS.cartUpdate, {
+              source: 'quick-add',
+              cartData: parsedState,
+            });
           })
           .catch(() => {
             // Commented out for now and will be fixed when BE issue is done https://github.com/Shopify/shopify/issues/440605
@@ -166,12 +193,16 @@ if (!customElements.get('quick-add-bulk')) {
       }
 
       renderSections(parsedState, ids) {
-        const intersection = this.queue.filter((element) => ids.includes(element.id));
+        const intersection = this.queue.filter((element) =>
+          ids.includes(element.id)
+        );
         if (intersection.length !== 0) return;
         this.getSectionsToRender().forEach((section) => {
           const sectionElement = document.getElementById(section.id);
           if (section.section === 'cart-drawer') {
-            sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', parsedState.items.length === 0);
+            sectionElement
+              .closest('cart-drawer')
+              ?.classList.toggle('is-empty', parsedState.items.length === 0);
           }
           const elementToReplace =
             sectionElement && sectionElement.querySelector(section.selector)


### PR DESCRIPTION
## Summary
- sanitize cart and quick-add updates with DOMPurify
- fall back to `textContent` where only text is needed
- add test ensuring inline handlers are stripped

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688aaa1f68e48328a4545eb8e79caad9