### PR TITLE
Sanitize innerHTML assignments

### DIFF
--- a/themes/website-v1/assets/cart-drawer.js
+++ b/themes/website-v1/assets/cart-drawer.js
@@ -1,3 +1,6 @@
+const DOMPurify = window.DOMPurify;
+
+
 class CartDrawer extends HTMLElement {
   constructor() {
     super();
@@ -80,7 +83,7 @@ class CartDrawer extends HTMLElement {
         : document.getElementById(section.id);
 
       if (!sectionElement) return;
-      sectionElement.innerHTML = this.getSectionInnerHTML(parsedState.sections[section.id], section.selector);
+      sectionElement.innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(parsedState.sections[section.id], section.selector));
     });
 
     setTimeout(() => {

--- a/themes/website-v1/assets/cart-notification.js
+++ b/themes/website-v1/assets/cart-notification.js
@@ -1,3 +1,6 @@
+const DOMPurify = window.DOMPurify;
+
+
 class CartNotification extends HTMLElement {
   constructor() {
     super();
@@ -37,10 +40,10 @@ class CartNotification extends HTMLElement {
   renderContents(parsedState) {
     this.cartItemKey = parsedState.key;
     this.getSectionsToRender().forEach((section) => {
-      document.getElementById(section.id).innerHTML = this.getSectionInnerHTML(
+      document.getElementById(section.id).innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(
         parsedState.sections[section.id],
         section.selector
-      );
+      ));
     });
 
     if (this.header) this.header.reveal();

--- a/themes/website-v1/assets/cart.js
+++ b/themes/website-v1/assets/cart.js
@@ -1,5 +1,5 @@
-const createDOMPurify = require('dompurify');
-const DOMPurify = createDOMPurify(window);
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
 
 class CartRemoveButton extends HTMLElement {
   constructor() {
@@ -121,7 +121,7 @@ class CartItems extends HTMLElement {
           if (sourceQty) {
             const sanitized = DOMPurify.sanitize(sourceQty.innerHTML);
             if (this.innerHTML !== sanitized) {
-              this.innerHTML = sanitized;
+              this.innerHTML = DOMPurify.sanitize(sanitized);
             }
           }
         })
@@ -203,7 +203,7 @@ class CartItems extends HTMLElement {
               )
             );
             if (elementToReplace.innerHTML !== newHtml) {
-              elementToReplace.innerHTML = newHtml;
+              elementToReplace.innerHTML = DOMPurify.sanitize(newHtml);
             }
           });
           const updatedValue = parsedState.items[line - 1] ? parsedState.items[line - 1].quantity : undefined;

--- a/themes/website-v1/assets/facets.js
+++ b/themes/website-v1/assets/facets.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class FacetFiltersForm extends HTMLElement {
   constructor() {
     super();
@@ -80,9 +83,9 @@ class FacetFiltersForm extends HTMLElement {
   }
 
   static renderProductGridContainer(html) {
-    document.getElementById('ProductGridContainer').innerHTML = new DOMParser()
+    document.getElementById('ProductGridContainer').innerHTML = DOMPurify.sanitize(new DOMParser()
       .parseFromString(html, 'text/html')
-      .getElementById('ProductGridContainer').innerHTML;
+      .getElementById('ProductGridContainer').innerHTML);
 
     document
       .getElementById('ProductGridContainer')
@@ -96,10 +99,10 @@ class FacetFiltersForm extends HTMLElement {
     const count = new DOMParser().parseFromString(html, 'text/html').getElementById('ProductCount').innerHTML;
     const container = document.getElementById('ProductCount');
     const containerDesktop = document.getElementById('ProductCountDesktop');
-    container.innerHTML = count;
+    container.innerHTML = DOMPurify.sanitize(count);
     container.classList.remove('loading');
     if (containerDesktop) {
-      containerDesktop.innerHTML = count;
+      containerDesktop.innerHTML = DOMPurify.sanitize(count);
       containerDesktop.classList.remove('loading');
     }
     const loadingSpinners = document.querySelectorAll(
@@ -136,7 +139,7 @@ class FacetFiltersForm extends HTMLElement {
       const currentElement = document.getElementById(elementToRender.id);
       // Element already rendered in the DOM so just update the innerHTML
       if (currentElement) {
-        document.getElementById(elementToRender.id).innerHTML = elementToRender.innerHTML;
+        document.getElementById(elementToRender.id).innerHTML = DOMPurify.sanitize(elementToRender.innerHTML);
       } else {
         if (index > 0) {
           const { className: previousElementClassName, id: previousElementId } = facetsToRender[index - 1];
@@ -182,7 +185,7 @@ class FacetFiltersForm extends HTMLElement {
     activeFacetElementSelectors.forEach((selector) => {
       const activeFacetsElement = html.querySelector(selector);
       if (!activeFacetsElement) return;
-      document.querySelector(selector).innerHTML = activeFacetsElement.innerHTML;
+      document.querySelector(selector).innerHTML = DOMPurify.sanitize(activeFacetsElement.innerHTML);
     });
 
     FacetFiltersForm.toggleActiveFacets(false);
@@ -193,7 +196,7 @@ class FacetFiltersForm extends HTMLElement {
 
     mobileElementSelectors.forEach((selector) => {
       if (!html.querySelector(selector)) return;
-      document.querySelector(selector).innerHTML = html.querySelector(selector).innerHTML;
+      document.querySelector(selector).innerHTML = DOMPurify.sanitize(html.querySelector(selector).innerHTML);
     });
 
     document.getElementById('FacetFiltersFormMobile').closest('menu-drawer').bindEvents();

--- a/themes/website-v1/assets/global.js
+++ b/themes/website-v1/assets/global.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 function getFocusableElements(container) {
   return Array.from(
     container.querySelectorAll(
@@ -56,7 +59,7 @@ class HTMLUpdateUtility {
 
   // Sets inner HTML and reinjects the script tags to allow execution. By default, scripts are disabled when using element.innerHTML.
   static setInnerHTML(element, html) {
-    element.innerHTML = html;
+    element.innerHTML = DOMPurify.sanitize(html);
     element.querySelectorAll('script').forEach((oldScriptTag) => {
       const newScriptTag = document.createElement('script');
       Array.from(oldScriptTag.attributes).forEach((attribute) => {
@@ -400,7 +403,7 @@ Shopify.CountryProvinceSelector.prototype = {
       for (let i = 0; i < provinces.length; i++) {
         const opt = document.createElement('option');
         opt.value = provinces[i][0];
-        opt.innerHTML = provinces[i][1];
+        opt.innerHTML = DOMPurify.sanitize(provinces[i][1]);
         this.provinceEl.appendChild(opt);
       }
 
@@ -418,7 +421,7 @@ Shopify.CountryProvinceSelector.prototype = {
     for (let i = 0, count = values.length; i < values.length; i++) {
       const opt = document.createElement('option');
       opt.value = values[i];
-      opt.innerHTML = values[i];
+      opt.innerHTML = DOMPurify.sanitize(values[i]);
       selector.appendChild(opt);
     }
   },
@@ -665,7 +668,7 @@ class BulkModal extends HTMLElement {
           .then((responseText) => {
             const html = new DOMParser().parseFromString(responseText, 'text/html');
             const sourceQty = html.querySelector('.quick-order-list-container').parentNode;
-            this.innerHTML = sourceQty.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
           })
           .catch((e) => {
             console.error(e);
@@ -1113,7 +1116,7 @@ class VariantSelects extends HTMLElement {
       );
     } else if (tagName === 'INPUT' && target.type === 'radio') {
       const selectedSwatchValue = target.closest(`.product-form__input`).querySelector('[data-selected-value]');
-      if (selectedSwatchValue) selectedSwatchValue.innerHTML = value;
+      if (selectedSwatchValue) selectedSwatchValue.innerHTML = DOMPurify.sanitize(value);
     }
   }
 
@@ -1159,11 +1162,11 @@ class ProductRecommendations extends HTMLElement {
       .then((response) => response.text())
       .then((text) => {
         const html = document.createElement('div');
-        html.innerHTML = text;
+        html.innerHTML = DOMPurify.sanitize(text);
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
-          this.innerHTML = recommendations.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(recommendations.innerHTML);
         }
 
         if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {

--- a/themes/website-v1/assets/localization-form.js
+++ b/themes/website-v1/assets/localization-form.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('localization-form')) {
   customElements.define(
     'localization-form',
@@ -169,10 +172,10 @@ if (!customElements.get('localization-form')) {
         });
 
         if (this.elements.liveRegion) {
-          this.elements.liveRegion.innerHTML = window.accessibilityStrings.countrySelectorSearchCount.replace(
+          this.elements.liveRegion.innerHTML = DOMPurify.sanitize(window.accessibilityStrings.countrySelectorSearchCount.replace(
             '[count]',
             visibleCountries
-          );
+          ));
         }
 
         this.querySelector('.country-selector').scrollTop = 0;

--- a/themes/website-v1/assets/media-gallery.js
+++ b/themes/website-v1/assets/media-gallery.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('media-gallery')) {
   customElements.define(
     'media-gallery',
@@ -87,7 +90,7 @@ if (!customElements.get('media-gallery')) {
         if (!image) return;
         image.onload = () => {
           this.elements.liveRegion.setAttribute('aria-hidden', false);
-          this.elements.liveRegion.innerHTML = window.accessibilityStrings.imageAvailable.replace('[index]', position);
+          this.elements.liveRegion.innerHTML = DOMPurify.sanitize(window.accessibilityStrings.imageAvailable.replace('[index]', position));
           setTimeout(() => {
             this.elements.liveRegion.setAttribute('aria-hidden', true);
           }, 2000);

--- a/themes/website-v1/assets/pickup-availability.js
+++ b/themes/website-v1/assets/pickup-availability.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('pickup-availability')) {
   customElements.define(
     'pickup-availability',
@@ -45,12 +48,12 @@ if (!customElements.get('pickup-availability')) {
           this.fetchAvailability(variant.id);
         } else {
           this.removeAttribute('available');
-          this.innerHTML = '';
+          this.innerHTML = DOMPurify.sanitize('');
         }
       }
 
       renderError() {
-        this.innerHTML = '';
+        this.innerHTML = DOMPurify.sanitize('');
         this.appendChild(this.errorHtml);
 
         this.querySelector('button').addEventListener('click', this.onClickRefreshList);
@@ -60,12 +63,12 @@ if (!customElements.get('pickup-availability')) {
         const drawer = document.querySelector('pickup-availability-drawer');
         if (drawer) drawer.remove();
         if (!sectionInnerHTML.querySelector('pickup-availability-preview')) {
-          this.innerHTML = '';
+          this.innerHTML = DOMPurify.sanitize('');
           this.removeAttribute('available');
           return;
         }
 
-        this.innerHTML = sectionInnerHTML.querySelector('pickup-availability-preview').outerHTML;
+        this.innerHTML = DOMPurify.sanitize(sectionInnerHTML.querySelector('pickup-availability-preview').outerHTML);
         this.setAttribute('available', '');
 
         document.body.appendChild(sectionInnerHTML.querySelector('pickup-availability-drawer'));

--- a/themes/website-v1/assets/predictive-search.js
+++ b/themes/website-v1/assets/predictive-search.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class PredictiveSearch extends SearchForm {
   constructor() {
     super();
@@ -226,7 +229,7 @@ class PredictiveSearch extends SearchForm {
   }
 
   renderSearchResults(resultsMarkup) {
-    this.predictiveSearchResults.innerHTML = resultsMarkup;
+    this.predictiveSearchResults.innerHTML = DOMPurify.sanitize(resultsMarkup);
     this.setAttribute('results', true);
 
     this.setLiveRegionResults();

--- a/themes/website-v1/assets/price-per-item.js
+++ b/themes/website-v1/assets/price-per-item.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('price-per-item')) {
   customElements.define(
     'price-per-item',
@@ -86,7 +89,11 @@ if (!customElements.get('price-per-item')) {
         for (let pair of this.qtyPricePairs) {
           if (this.currentQtyForVolumePricing >= pair[0]) {
             const pricePerItemCurrent = document.querySelector(`price-per-item[id^="Price-Per-Item-${this.dataset.sectionId || this.dataset.variantId}"] .price-per-item span`);
-            this.classList.contains('variant-item__price-per-item') ? pricePerItemCurrent.innerHTML = window.quickOrderListStrings.each.replace('[money]', pair[1]) : pricePerItemCurrent.innerHTML = pair[1];
+            this.classList.contains('variant-item__price-per-item')
+              ? (pricePerItemCurrent.innerHTML = DOMPurify.sanitize(
+                  window.quickOrderListStrings.each.replace('[money]', pair[1])
+                ))
+              : (pricePerItemCurrent.innerHTML = DOMPurify.sanitize(pair[1]));
             break;
           }
         }

--- a/themes/website-v1/assets/product-info.js
+++ b/themes/website-v1/assets/product-info.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('product-info')) {
   customElements.define(
     'product-info',
@@ -99,7 +102,7 @@ if (!customElements.get('product-info')) {
           this.updateURL(productUrl, variant?.id);
 
           if (updateFullPage) {
-            document.querySelector('head title').innerHTML = html.querySelector('head title').innerHTML;
+            document.querySelector('head title').innerHTML = DOMPurify.sanitize(html.querySelector('head title').innerHTML);
 
             HTMLUpdateUtility.viewTransition(
               document.querySelector('main'),
@@ -186,7 +189,7 @@ if (!customElements.get('product-info')) {
             const source = html.getElementById(`${id}-${this.sectionId}`);
             const destination = this.querySelector(`#${id}-${this.dataset.section}`);
             if (source && destination) {
-              destination.innerHTML = source.innerHTML;
+              destination.innerHTML = DOMPurify.sanitize(source.innerHTML);
               destination.classList.toggle('hidden', shouldHide(source));
             }
           };
@@ -312,7 +315,7 @@ if (!customElements.get('product-info')) {
         // update media modal
         const modalContent = this.productModal?.querySelector(`.product-media-modal__content`);
         const newModalContent = html.querySelector(`product-modal .product-media-modal__content`);
-        if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
+        if (modalContent && newModalContent) modalContent.innerHTML = DOMPurify.sanitize(newModalContent.innerHTML);
       }
 
       setQuantityBoundries() {
@@ -376,7 +379,7 @@ if (!customElements.get('product-info')) {
               }
             }
           } else {
-            current.innerHTML = updated.innerHTML;
+            current.innerHTML = DOMPurify.sanitize(updated.innerHTML);
           }
         }
       }

--- a/themes/website-v1/assets/quick-add-bulk.js
+++ b/themes/website-v1/assets/quick-add-bulk.js
@@ -1,6 +1,5 @@
-const createDOMPurify = require('dompurify');
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
 
-const DOMPurify = createDOMPurify(window);
 
 class QuickAddBulk extends BulkAdd {
   constructor() {
@@ -101,7 +100,7 @@ class QuickAddBulk extends BulkAdd {
           if (sourceQty) {
             const sanitized = DOMPurify.sanitize(sourceQty.innerHTML);
             if (this.innerHTML !== sanitized) {
-              this.innerHTML = sanitized;
+              this.innerHTML = DOMPurify.sanitize(sanitized);
             }
           }
           resolve();
@@ -194,7 +193,7 @@ class QuickAddBulk extends BulkAdd {
           )
         );
         if (elementToReplace.innerHTML !== newHtml) {
-          elementToReplace.innerHTML = newHtml;
+          elementToReplace.innerHTML = DOMPurify.sanitize(newHtml);
         }
       }
     });

--- a/themes/website-v1/assets/quick-add.js
+++ b/themes/website-v1/assets/quick-add.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('quick-add-modal')) {
   customElements.define(
     'quick-add-modal',
@@ -14,7 +17,7 @@ if (!customElements.get('quick-add-modal')) {
       hide(preventFocus = false) {
         const cartNotification = document.querySelector('cart-notification') || document.querySelector('cart-drawer');
         if (cartNotification) cartNotification.setActiveElement(this.openedBy);
-        this.modalContent.innerHTML = '';
+        this.modalContent.innerHTML = DOMPurify.sanitize('');
 
         if (preventFocus) this.openedBy = null;
         super.hide();
@@ -80,7 +83,7 @@ if (!customElements.get('quick-add-modal')) {
 
         const oldId = sectionId;
         const newId = `quickadd-${sectionId}`;
-        productElement.innerHTML = productElement.innerHTML.replaceAll(oldId, newId);
+        productElement.innerHTML = DOMPurify.sanitize(productElement.innerHTML.replaceAll(oldId, newId));
         Array.from(productElement.attributes).forEach((attribute) => {
           if (attribute.value.includes(oldId)) {
             productElement.setAttribute(attribute.name, attribute.value.replace(oldId, newId));

--- a/themes/website-v1/assets/quick-order-list.js
+++ b/themes/website-v1/assets/quick-order-list.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 globalThis.subscribe = globalThis.subscribe || undefined;
 
 if (!customElements.get('quick-order-list')) {
@@ -193,7 +196,7 @@ if (!customElements.get('quick-order-list')) {
               return;
             }
 
-            this.innerHTML = responseQuickOrderList.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(responseQuickOrderList.innerHTML);
             this.initEventListeners();
           })
           .catch((e) => {
@@ -222,7 +225,7 @@ if (!customElements.get('quick-order-list')) {
 
             const total = this.getTotalBar();
             if (total) {
-              total.innerHTML = newSection.querySelector('.quick-order-list__total').innerHTML;
+              total.innerHTML = DOMPurify.sanitize(newSection.querySelector('.quick-order-list__total').innerHTML);
             }
 
             const table = this.quickOrderListTable;
@@ -232,7 +235,7 @@ if (!customElements.get('quick-order-list')) {
             const shouldUpdateVariants =
               this.currentPage === (newSection.querySelector('.pagination-wrapper')?.dataset.page ?? '1');
             if (newTable && shouldUpdateVariants) {
-              table.innerHTML = newTable.innerHTML;
+              table.innerHTML = DOMPurify.sanitize(newTable.innerHTML);
 
               const newFocusTarget = this.querySelector(`[data-target='${focusTarget}']`);
               if (newFocusTarget) {
@@ -243,9 +246,9 @@ if (!customElements.get('quick-order-list')) {
             }
           } else if (section === 'cart-drawer') {
             sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', items.length === 0);
-            sectionElement.querySelector(selector).innerHTML = newSection.innerHTML;
+            sectionElement.querySelector(selector).innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           } else {
-            sectionElement.innerHTML = newSection.innerHTML;
+            sectionElement.innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           }
         });
       }
@@ -372,7 +375,7 @@ if (!customElements.get('quick-order-list')) {
         const errorElements = document.querySelectorAll('.quick-order-list-error');
 
         errorElements.forEach((errorElement) => {
-          errorElement.innerHTML = '';
+          errorElement.innerHTML = DOMPurify.sanitize('');
           if (!message) return;
           const updatedMessageElement = this.errorMessageTemplate.cloneNode(true);
           updatedMessageElement.content.querySelector('.quick-order-list-error-message').innerText = message;
@@ -385,7 +388,7 @@ if (!customElements.get('quick-order-list')) {
         const icons = this.querySelectorAll('.quick-order-list__message-icon');
 
         if (quantity === null || isNaN(quantity)) {
-          messages.forEach((message) => (message.innerHTML = ''));
+          messages.forEach((message) => (message.innerHTML = DOMPurify.sanitize('')));
           icons.forEach((icon) => icon.classList.add('hidden'));
           return;
         }
@@ -401,7 +404,7 @@ if (!customElements.get('quick-order-list')) {
           ? window.quickOrderListStrings.itemAdded
           : window.quickOrderListStrings.itemsAdded;
 
-        messages.forEach((msg) => (msg.innerHTML = textTemplate.replace('[quantity]', absQuantity)));
+        messages.forEach((msg) => (msg.innerHTML = DOMPurify.sanitize(textTemplate.replace('[quantity]', absQuantity))));
 
         if (!isQuantityNegative) {
           icons.forEach((i) => i.classList.remove('hidden'));
@@ -421,7 +424,7 @@ if (!customElements.get('quick-order-list')) {
       updateLiveRegions(id, message) {
         const variantItemErrorDesktop = document.getElementById(`Quick-order-list-item-error-desktop-${id}`);
         if (variantItemErrorDesktop) {
-          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
           variantItemErrorDesktop.closest('tr').classList.remove('hidden');
         }
 
@@ -429,7 +432,7 @@ if (!customElements.get('quick-order-list')) {
           `Quick-order-list-item-error-mobile-${id}`
         );
         if (variantItemErrorMobile) {
-          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
         }
 
         this.querySelector('#shopping-cart-variant-item-status').setAttribute('aria-hidden', true);

--- a/themes/website-v1/assets/recipient-form.js
+++ b/themes/website-v1/assets/recipient-form.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('recipient-form')) {
   customElements.define(
     'recipient-form',
@@ -156,7 +159,7 @@ if (!customElements.get('recipient-form')) {
       clearErrorMessage() {
         this.errorMessageWrapper.hidden = true;
 
-        if (this.errorMessageList) this.errorMessageList.innerHTML = '';
+        if (this.errorMessageList) this.errorMessageList.innerHTML = DOMPurify.sanitize('');
 
         this.querySelectorAll('.recipient-fields .form__message').forEach((field) => {
           field.classList.add('hidden');

--- a/themes/website-v2/assets/quick-order-list.js
+++ b/themes/website-v2/assets/quick-order-list.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('quick-order-list')) {
   customElements.define(
     'quick-order-list',
@@ -186,7 +189,7 @@ if (!customElements.get('quick-order-list')) {
               return;
             }
 
-            this.innerHTML = responseQuickOrderList.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(responseQuickOrderList.innerHTML);
             this.initEventListeners();
           })
           .catch((e) => {
@@ -215,7 +218,7 @@ if (!customElements.get('quick-order-list')) {
 
             const total = this.getTotalBar();
             if (total) {
-              total.innerHTML = newSection.querySelector('.quick-order-list__total').innerHTML;
+              total.innerHTML = DOMPurify.sanitize(newSection.querySelector('.quick-order-list__total').innerHTML);
             }
 
             const table = this.quickOrderListTable;
@@ -225,7 +228,7 @@ if (!customElements.get('quick-order-list')) {
             const shouldUpdateVariants =
               this.currentPage === (newSection.querySelector('.pagination-wrapper')?.dataset.page ?? '1');
             if (newTable && shouldUpdateVariants) {
-              table.innerHTML = newTable.innerHTML;
+              table.innerHTML = DOMPurify.sanitize(newTable.innerHTML);
 
               const newFocusTarget = this.querySelector(`[data-target='${focusTarget}']`);
               if (newFocusTarget) {
@@ -236,9 +239,9 @@ if (!customElements.get('quick-order-list')) {
             }
           } else if (section === 'cart-drawer') {
             sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', items.length === 0);
-            sectionElement.querySelector(selector).innerHTML = newSection.innerHTML;
+            sectionElement.querySelector(selector).innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           } else {
-            sectionElement.innerHTML = newSection.innerHTML;
+            sectionElement.innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           }
         });
       }
@@ -365,7 +368,7 @@ if (!customElements.get('quick-order-list')) {
         const errorElements = document.querySelectorAll('.quick-order-list-error');
 
         errorElements.forEach((errorElement) => {
-          errorElement.innerHTML = '';
+          errorElement.innerHTML = DOMPurify.sanitize('');
           if (!message) return;
           const updatedMessageElement = this.errorMessageTemplate.cloneNode(true);
           updatedMessageElement.content.querySelector('.quick-order-list-error-message').innerText = message;
@@ -378,7 +381,7 @@ if (!customElements.get('quick-order-list')) {
         const icons = this.querySelectorAll('.quick-order-list__message-icon');
 
         if (quantity === null || isNaN(quantity)) {
-          messages.forEach((message) => (message.innerHTML = ''));
+          messages.forEach((message) => (message.innerHTML = DOMPurify.sanitize('')));
           icons.forEach((icon) => icon.classList.add('hidden'));
           return;
         }
@@ -394,7 +397,7 @@ if (!customElements.get('quick-order-list')) {
           ? window.quickOrderListStrings.itemAdded
           : window.quickOrderListStrings.itemsAdded;
 
-        messages.forEach((msg) => (msg.innerHTML = textTemplate.replace('[quantity]', absQuantity)));
+        messages.forEach((msg) => (msg.innerHTML = DOMPurify.sanitize(textTemplate.replace('[quantity]', absQuantity))));
 
         if (!isQuantityNegative) {
           icons.forEach((i) => i.classList.remove('hidden'));
@@ -414,11 +417,11 @@ if (!customElements.get('quick-order-list')) {
       updateLiveRegions(id, message) {
         const variantItemErrorDesktop = document.getElementById(`Quick-order-list-item-error-desktop-${id}`);
         if (variantItemErrorDesktop) {
-          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
           variantItemErrorDesktop.closest('tr').classList.remove('hidden');
         }
         if (variantItemErrorMobile)
-          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
 
         this.querySelector('#shopping-cart-variant-item-status').setAttribute('aria-hidden', true);
 

--- a/themes/website-v3/assets/cart-drawer.js
+++ b/themes/website-v3/assets/cart-drawer.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class CartDrawer extends HTMLElement {
   constructor() {
     super();
@@ -80,7 +83,7 @@ class CartDrawer extends HTMLElement {
         : document.getElementById(section.id);
 
       if (!sectionElement) return;
-      sectionElement.innerHTML = this.getSectionInnerHTML(parsedState.sections[section.id], section.selector);
+      sectionElement.innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(parsedState.sections[section.id], section.selector));
     });
 
     setTimeout(() => {

--- a/themes/website-v3/assets/cart-notification.js
+++ b/themes/website-v3/assets/cart-notification.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class CartNotification extends HTMLElement {
   constructor() {
     super();
@@ -37,10 +40,10 @@ class CartNotification extends HTMLElement {
   renderContents(parsedState) {
     this.cartItemKey = parsedState.key;
     this.getSectionsToRender().forEach((section) => {
-      document.getElementById(section.id).innerHTML = this.getSectionInnerHTML(
+      document.getElementById(section.id).innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(
         parsedState.sections[section.id],
         section.selector
-      );
+      ));
     });
 
     if (this.header) this.header.reveal();

--- a/themes/website-v3/assets/cart.js
+++ b/themes/website-v3/assets/cart.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class CartRemoveButton extends HTMLElement {
   constructor() {
     super();
@@ -133,7 +136,7 @@ class CartItems extends HTMLElement {
             'text/html'
           );
           const sourceQty = html.querySelector('cart-items');
-          this.innerHTML = sourceQty.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
         })
         .catch((e) => {
           console.error(e);
@@ -185,10 +188,10 @@ class CartItems extends HTMLElement {
       const elementToReplace =
         document.getElementById(section.id).querySelector(section.selector) ||
         document.getElementById(section.id);
-      elementToReplace.innerHTML = this.getSectionInnerHTML(
+      elementToReplace.innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(
         state.sections[section.section],
         section.selector
-      );
+      ));
     });
   }
 

--- a/themes/website-v3/assets/facets.js
+++ b/themes/website-v3/assets/facets.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class FacetFiltersForm extends HTMLElement {
   constructor() {
     super();
@@ -80,9 +83,9 @@ class FacetFiltersForm extends HTMLElement {
   }
 
   static renderProductGridContainer(html) {
-    document.getElementById('ProductGridContainer').innerHTML = new DOMParser()
+    document.getElementById('ProductGridContainer').innerHTML = DOMPurify.sanitize(new DOMParser()
       .parseFromString(html, 'text/html')
-      .getElementById('ProductGridContainer').innerHTML;
+      .getElementById('ProductGridContainer').innerHTML);
 
     document
       .getElementById('ProductGridContainer')
@@ -96,10 +99,10 @@ class FacetFiltersForm extends HTMLElement {
     const count = new DOMParser().parseFromString(html, 'text/html').getElementById('ProductCount').innerHTML;
     const container = document.getElementById('ProductCount');
     const containerDesktop = document.getElementById('ProductCountDesktop');
-    container.innerHTML = count;
+    container.innerHTML = DOMPurify.sanitize(count);
     container.classList.remove('loading');
     if (containerDesktop) {
-      containerDesktop.innerHTML = count;
+      containerDesktop.innerHTML = DOMPurify.sanitize(count);
       containerDesktop.classList.remove('loading');
     }
     const loadingSpinners = document.querySelectorAll(
@@ -136,7 +139,7 @@ class FacetFiltersForm extends HTMLElement {
       const currentElement = document.getElementById(elementToRender.id);
       // Element already rendered in the DOM so just update the innerHTML
       if (currentElement) {
-        document.getElementById(elementToRender.id).innerHTML = elementToRender.innerHTML;
+        document.getElementById(elementToRender.id).innerHTML = DOMPurify.sanitize(elementToRender.innerHTML);
       } else {
         if (index > 0) {
           const { className: previousElementClassName, id: previousElementId } = facetsToRender[index - 1];
@@ -182,7 +185,7 @@ class FacetFiltersForm extends HTMLElement {
     activeFacetElementSelectors.forEach((selector) => {
       const activeFacetsElement = html.querySelector(selector);
       if (!activeFacetsElement) return;
-      document.querySelector(selector).innerHTML = activeFacetsElement.innerHTML;
+      document.querySelector(selector).innerHTML = DOMPurify.sanitize(activeFacetsElement.innerHTML);
     });
 
     FacetFiltersForm.toggleActiveFacets(false);
@@ -193,7 +196,7 @@ class FacetFiltersForm extends HTMLElement {
 
     mobileElementSelectors.forEach((selector) => {
       if (!html.querySelector(selector)) return;
-      document.querySelector(selector).innerHTML = html.querySelector(selector).innerHTML;
+      document.querySelector(selector).innerHTML = DOMPurify.sanitize(html.querySelector(selector).innerHTML);
     });
 
     document.getElementById('FacetFiltersFormMobile').closest('menu-drawer').bindEvents();

--- a/themes/website-v3/assets/global.js
+++ b/themes/website-v3/assets/global.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 function getFocusableElements(container) {
   return Array.from(
     container.querySelectorAll(
@@ -56,7 +59,7 @@ class HTMLUpdateUtility {
 
   // Sets inner HTML and reinjects the script tags to allow execution. By default, scripts are disabled when using element.innerHTML.
   static setInnerHTML(element, html) {
-    element.innerHTML = html;
+    element.innerHTML = DOMPurify.sanitize(html);
     element.querySelectorAll('script').forEach((oldScriptTag) => {
       const newScriptTag = document.createElement('script');
       Array.from(oldScriptTag.attributes).forEach((attribute) => {
@@ -400,7 +403,7 @@ Shopify.CountryProvinceSelector.prototype = {
       for (var i = 0; i < provinces.length; i++) {
         var opt = document.createElement('option');
         opt.value = provinces[i][0];
-        opt.innerHTML = provinces[i][1];
+        opt.innerHTML = DOMPurify.sanitize(provinces[i][1]);
         this.provinceEl.appendChild(opt);
       }
 
@@ -418,7 +421,7 @@ Shopify.CountryProvinceSelector.prototype = {
     for (var i = 0, count = values.length; i < values.length; i++) {
       var opt = document.createElement('option');
       opt.value = values[i];
-      opt.innerHTML = values[i];
+      opt.innerHTML = DOMPurify.sanitize(values[i]);
       selector.appendChild(opt);
     }
   },
@@ -665,7 +668,7 @@ class BulkModal extends HTMLElement {
           .then((responseText) => {
             const html = new DOMParser().parseFromString(responseText, 'text/html');
             const sourceQty = html.querySelector('.quick-order-list-container').parentNode;
-            this.innerHTML = sourceQty.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
           })
           .catch((e) => {
             console.error(e);
@@ -1113,7 +1116,7 @@ class VariantSelects extends HTMLElement {
       );
     } else if (tagName === 'INPUT' && target.type === 'radio') {
       const selectedSwatchValue = target.closest(`.product-form__input`).querySelector('[data-selected-value]');
-      if (selectedSwatchValue) selectedSwatchValue.innerHTML = value;
+      if (selectedSwatchValue) selectedSwatchValue.innerHTML = DOMPurify.sanitize(value);
     }
   }
 
@@ -1159,11 +1162,11 @@ class ProductRecommendations extends HTMLElement {
       .then((response) => response.text())
       .then((text) => {
         const html = document.createElement('div');
-        html.innerHTML = text;
+        html.innerHTML = DOMPurify.sanitize(text);
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
-          this.innerHTML = recommendations.innerHTML;
+          this.innerHTML = DOMPurify.sanitize(recommendations.innerHTML);
         }
 
         if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {

--- a/themes/website-v3/assets/localization-form.js
+++ b/themes/website-v3/assets/localization-form.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('localization-form')) {
   customElements.define(
     'localization-form',
@@ -169,10 +172,10 @@ if (!customElements.get('localization-form')) {
         });
 
         if (this.elements.liveRegion) {
-          this.elements.liveRegion.innerHTML = window.accessibilityStrings.countrySelectorSearchCount.replace(
+          this.elements.liveRegion.innerHTML = DOMPurify.sanitize(window.accessibilityStrings.countrySelectorSearchCount.replace(
             '[count]',
             visibleCountries
-          );
+          ));
         }
 
         this.querySelector('.country-selector').scrollTop = 0;

--- a/themes/website-v3/assets/media-gallery.js
+++ b/themes/website-v3/assets/media-gallery.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('media-gallery')) {
   customElements.define(
     'media-gallery',
@@ -87,7 +90,7 @@ if (!customElements.get('media-gallery')) {
         if (!image) return;
         image.onload = () => {
           this.elements.liveRegion.setAttribute('aria-hidden', false);
-          this.elements.liveRegion.innerHTML = window.accessibilityStrings.imageAvailable.replace('[index]', position);
+          this.elements.liveRegion.innerHTML = DOMPurify.sanitize(window.accessibilityStrings.imageAvailable.replace('[index]', position));
           setTimeout(() => {
             this.elements.liveRegion.setAttribute('aria-hidden', true);
           }, 2000);

--- a/themes/website-v3/assets/pickup-availability.js
+++ b/themes/website-v3/assets/pickup-availability.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('pickup-availability')) {
   customElements.define(
     'pickup-availability',
@@ -45,12 +48,12 @@ if (!customElements.get('pickup-availability')) {
           this.fetchAvailability(variant.id);
         } else {
           this.removeAttribute('available');
-          this.innerHTML = '';
+          this.innerHTML = DOMPurify.sanitize('');
         }
       }
 
       renderError() {
-        this.innerHTML = '';
+        this.innerHTML = DOMPurify.sanitize('');
         this.appendChild(this.errorHtml);
 
         this.querySelector('button').addEventListener('click', this.onClickRefreshList);
@@ -60,12 +63,12 @@ if (!customElements.get('pickup-availability')) {
         const drawer = document.querySelector('pickup-availability-drawer');
         if (drawer) drawer.remove();
         if (!sectionInnerHTML.querySelector('pickup-availability-preview')) {
-          this.innerHTML = '';
+          this.innerHTML = DOMPurify.sanitize('');
           this.removeAttribute('available');
           return;
         }
 
-        this.innerHTML = sectionInnerHTML.querySelector('pickup-availability-preview').outerHTML;
+        this.innerHTML = DOMPurify.sanitize(sectionInnerHTML.querySelector('pickup-availability-preview').outerHTML);
         this.setAttribute('available', '');
 
         document.body.appendChild(sectionInnerHTML.querySelector('pickup-availability-drawer'));

--- a/themes/website-v3/assets/predictive-search.js
+++ b/themes/website-v3/assets/predictive-search.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 class PredictiveSearch extends SearchForm {
   constructor() {
     super();
@@ -226,7 +229,7 @@ class PredictiveSearch extends SearchForm {
   }
 
   renderSearchResults(resultsMarkup) {
-    this.predictiveSearchResults.innerHTML = resultsMarkup;
+    this.predictiveSearchResults.innerHTML = DOMPurify.sanitize(resultsMarkup);
     this.setAttribute('results', true);
 
     this.setLiveRegionResults();

--- a/themes/website-v3/assets/price-per-item.js
+++ b/themes/website-v3/assets/price-per-item.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('price-per-item')) {
   customElements.define(
     'price-per-item',
@@ -94,9 +97,10 @@ if (!customElements.get('price-per-item')) {
               `price-per-item[id^="Price-Per-Item-${this.dataset.sectionId || this.dataset.variantId}"] .price-per-item span`
             );
             this.classList.contains('variant-item__price-per-item')
-              ? (pricePerItemCurrent.innerHTML =
-                  window.quickOrderListStrings.each.replace('[money]', pair[1]))
-              : (pricePerItemCurrent.innerHTML = pair[1]);
+              ? (pricePerItemCurrent.innerHTML = DOMPurify.sanitize(
+                  window.quickOrderListStrings.each.replace('[money]', pair[1])
+                ))
+              : (pricePerItemCurrent.innerHTML = DOMPurify.sanitize(pair[1]));
             break;
           }
         }

--- a/themes/website-v3/assets/product-info.js
+++ b/themes/website-v3/assets/product-info.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('product-info')) {
   customElements.define(
     'product-info',
@@ -97,7 +100,7 @@ if (!customElements.get('product-info')) {
           this.updateURL(productUrl, variant?.id);
 
           if (updateFullPage) {
-            document.querySelector('head title').innerHTML = html.querySelector('head title').innerHTML;
+            document.querySelector('head title').innerHTML = DOMPurify.sanitize(html.querySelector('head title').innerHTML);
 
             HTMLUpdateUtility.viewTransition(
               document.querySelector('main'),
@@ -184,7 +187,7 @@ if (!customElements.get('product-info')) {
             const source = html.getElementById(`${id}-${this.sectionId}`);
             const destination = this.querySelector(`#${id}-${this.dataset.section}`);
             if (source && destination) {
-              destination.innerHTML = source.innerHTML;
+              destination.innerHTML = DOMPurify.sanitize(source.innerHTML);
               destination.classList.toggle('hidden', shouldHide(source));
             }
           };
@@ -310,7 +313,7 @@ if (!customElements.get('product-info')) {
         // update media modal
         const modalContent = this.productModal?.querySelector(`.product-media-modal__content`);
         const newModalContent = html.querySelector(`product-modal .product-media-modal__content`);
-        if (modalContent && newModalContent) modalContent.innerHTML = newModalContent.innerHTML;
+        if (modalContent && newModalContent) modalContent.innerHTML = DOMPurify.sanitize(newModalContent.innerHTML);
       }
 
       setQuantityBoundries() {
@@ -374,7 +377,7 @@ if (!customElements.get('product-info')) {
               }
             }
           } else {
-            current.innerHTML = updated.innerHTML;
+            current.innerHTML = DOMPurify.sanitize(updated.innerHTML);
           }
         }
       }

--- a/themes/website-v3/assets/quick-add-bulk.js
+++ b/themes/website-v3/assets/quick-add-bulk.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('quick-add-bulk')) {
   customElements.define(
     'quick-add-bulk',
@@ -102,7 +105,7 @@ if (!customElements.get('quick-add-bulk')) {
               const html = new DOMParser().parseFromString(responseText, 'text/html');
               const sourceQty = html.querySelector(`#quick-add-bulk-${this.dataset.index}-${this.sectionId}`);
               if (sourceQty) {
-                this.innerHTML = sourceQty.innerHTML;
+                this.innerHTML = DOMPurify.sanitize(sourceQty.innerHTML);
               }
               resolve();
             })
@@ -187,10 +190,10 @@ if (!customElements.get('quick-add-bulk')) {
               ? sectionElement.querySelector(section.selector)
               : sectionElement;
           if (elementToReplace) {
-            elementToReplace.innerHTML = this.getSectionInnerHTML(
+            elementToReplace.innerHTML = DOMPurify.sanitize(this.getSectionInnerHTML(
               parsedState.sections[section.section],
               section.selector
-            );
+            ));
           }
         });
 

--- a/themes/website-v3/assets/quick-add.js
+++ b/themes/website-v3/assets/quick-add.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('quick-add-modal')) {
   customElements.define(
     'quick-add-modal',
@@ -14,7 +17,7 @@ if (!customElements.get('quick-add-modal')) {
       hide(preventFocus = false) {
         const cartNotification = document.querySelector('cart-notification') || document.querySelector('cart-drawer');
         if (cartNotification) cartNotification.setActiveElement(this.openedBy);
-        this.modalContent.innerHTML = '';
+        this.modalContent.innerHTML = DOMPurify.sanitize('');
 
         if (preventFocus) this.openedBy = null;
         super.hide();
@@ -80,7 +83,7 @@ if (!customElements.get('quick-add-modal')) {
 
         const oldId = sectionId;
         const newId = `quickadd-${sectionId}`;
-        productElement.innerHTML = productElement.innerHTML.replaceAll(oldId, newId);
+        productElement.innerHTML = DOMPurify.sanitize(productElement.innerHTML.replaceAll(oldId, newId));
         Array.from(productElement.attributes).forEach((attribute) => {
           if (attribute.value.includes(oldId)) {
             productElement.setAttribute(attribute.name, attribute.value.replace(oldId, newId));

--- a/themes/website-v3/assets/quick-order-list.js
+++ b/themes/website-v3/assets/quick-order-list.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('quick-order-list')) {
   customElements.define(
     'quick-order-list',
@@ -191,7 +194,7 @@ if (!customElements.get('quick-order-list')) {
               return;
             }
 
-            this.innerHTML = responseQuickOrderList.innerHTML;
+            this.innerHTML = DOMPurify.sanitize(responseQuickOrderList.innerHTML);
             this.initEventListeners();
           })
           .catch((e) => {
@@ -220,7 +223,7 @@ if (!customElements.get('quick-order-list')) {
 
             const total = this.getTotalBar();
             if (total) {
-              total.innerHTML = newSection.querySelector('.quick-order-list__total').innerHTML;
+              total.innerHTML = DOMPurify.sanitize(newSection.querySelector('.quick-order-list__total').innerHTML);
             }
 
             const table = this.quickOrderListTable;
@@ -230,7 +233,7 @@ if (!customElements.get('quick-order-list')) {
             const shouldUpdateVariants =
               this.currentPage === (newSection.querySelector('.pagination-wrapper')?.dataset.page ?? '1');
             if (newTable && shouldUpdateVariants) {
-              table.innerHTML = newTable.innerHTML;
+              table.innerHTML = DOMPurify.sanitize(newTable.innerHTML);
 
               const newFocusTarget = this.querySelector(`[data-target='${focusTarget}']`);
               if (newFocusTarget) {
@@ -241,9 +244,9 @@ if (!customElements.get('quick-order-list')) {
             }
           } else if (section === 'cart-drawer') {
             sectionElement.closest('cart-drawer')?.classList.toggle('is-empty', items.length === 0);
-            sectionElement.querySelector(selector).innerHTML = newSection.innerHTML;
+            sectionElement.querySelector(selector).innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           } else {
-            sectionElement.innerHTML = newSection.innerHTML;
+            sectionElement.innerHTML = DOMPurify.sanitize(newSection.innerHTML);
           }
         });
       }
@@ -370,7 +373,7 @@ if (!customElements.get('quick-order-list')) {
         const errorElements = document.querySelectorAll('.quick-order-list-error');
 
         errorElements.forEach((errorElement) => {
-          errorElement.innerHTML = '';
+          errorElement.innerHTML = DOMPurify.sanitize('');
           if (!message) return;
           const updatedMessageElement = this.errorMessageTemplate.cloneNode(true);
           updatedMessageElement.content.querySelector('.quick-order-list-error-message').innerText = message;
@@ -383,7 +386,7 @@ if (!customElements.get('quick-order-list')) {
         const icons = this.querySelectorAll('.quick-order-list__message-icon');
 
         if (quantity === null || isNaN(quantity)) {
-          messages.forEach((message) => (message.innerHTML = ''));
+          messages.forEach((message) => (message.innerHTML = DOMPurify.sanitize('')));
           icons.forEach((icon) => icon.classList.add('hidden'));
           return;
         }
@@ -399,7 +402,7 @@ if (!customElements.get('quick-order-list')) {
           ? window.quickOrderListStrings.itemAdded
           : window.quickOrderListStrings.itemsAdded;
 
-        messages.forEach((msg) => (msg.innerHTML = textTemplate.replace('[quantity]', absQuantity)));
+        messages.forEach((msg) => (msg.innerHTML = DOMPurify.sanitize(textTemplate.replace('[quantity]', absQuantity))));
 
         if (!isQuantityNegative) {
           icons.forEach((i) => i.classList.remove('hidden'));
@@ -419,11 +422,11 @@ if (!customElements.get('quick-order-list')) {
       updateLiveRegions(id, message) {
         const variantItemErrorDesktop = document.getElementById(`Quick-order-list-item-error-desktop-${id}`);
         if (variantItemErrorDesktop) {
-          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorDesktop.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
           variantItemErrorDesktop.closest('tr').classList.remove('hidden');
         }
         if (variantItemErrorMobile)
-          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = message;
+          variantItemErrorMobile.querySelector('.variant-item__error-text').innerHTML = DOMPurify.sanitize(message);
 
         this.querySelector('#shopping-cart-variant-item-status').setAttribute('aria-hidden', true);
 

--- a/themes/website-v3/assets/recipient-form.js
+++ b/themes/website-v3/assets/recipient-form.js
@@ -1,3 +1,6 @@
+const DOMPurify = typeof require !== 'undefined' ? require('dompurify')(window) : window.DOMPurify;
+
+
 if (!customElements.get('recipient-form')) {
   customElements.define(
     'recipient-form',
@@ -156,7 +159,7 @@ if (!customElements.get('recipient-form')) {
       clearErrorMessage() {
         this.errorMessageWrapper.hidden = true;
 
-        if (this.errorMessageList) this.errorMessageList.innerHTML = '';
+        if (this.errorMessageList) this.errorMessageList.innerHTML = DOMPurify.sanitize('');
 
         this.querySelectorAll('.recipient-fields .form__message').forEach((field) => {
           field.classList.add('hidden');


### PR DESCRIPTION
## Summary
- import DOMPurify in theme scripts
- sanitize all `innerHTML` assignments
- ensure helper utilities sanitize inserted HTML

## Testing
- `npm test` *(fails: QuickOrderList and MainSearch tests)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b778d388483288bee7a0ba59e498a