### PR TITLE
Add CSP meta tag to Shopify theme layouts

### DIFF
--- a/themes/comma/website/comma-website_v2/layout/theme.liquid
+++ b/themes/comma/website/comma-website_v2/layout/theme.liquid
@@ -39,6 +39,7 @@
       <script src="{{ 'animations.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self';">
     {{ content_for_header }}
 
     {%- liquid

--- a/themes/layout/theme.liquid
+++ b/themes/layout/theme.liquid
@@ -39,6 +39,7 @@
       <script src="{{ 'animations.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self';">
     {{ content_for_header }}
 
     {%- liquid

--- a/themes/nome-ror-as/website/nome-theme-code_FINAL/layout/theme.liquid
+++ b/themes/nome-ror-as/website/nome-theme-code_FINAL/layout/theme.liquid
@@ -39,6 +39,7 @@
       <script src="{{ 'animations.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self';">
     {{ content_for_header }}
 
     {%- liquid

--- a/themes/website-v1/layout/theme.liquid
+++ b/themes/website-v1/layout/theme.liquid
@@ -39,6 +39,7 @@
       <script src="/dist/assets/animations.min.js" defer="defer"></script>
     {%- endif -%}
 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self';">
     {{ content_for_header }}
 
     {%- liquid

--- a/themes/website-v2/layout/theme.liquid
+++ b/themes/website-v2/layout/theme.liquid
@@ -39,6 +39,7 @@
       <script src="{{ 'animations.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
 
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self';">
     {{ content_for_header }}
 
     {%- liquid


### PR DESCRIPTION
## Summary
- add `Content-Security-Policy` meta tag above `content_for_header` in theme layouts
- ensure HTML linter passes

## Testing
- `npm run lint:html`

------
https://chatgpt.com/codex/tasks/task_e_688bec8a97d08328bcd68ca1f394d7d1